### PR TITLE
feat: remote coding session store safe slice (#10)

### DIFF
--- a/packages/valor-cli/src/SessionManager.test.ts
+++ b/packages/valor-cli/src/SessionManager.test.ts
@@ -14,13 +14,21 @@ describe('SessionManager', () => {
   });
 
   afterEach(async () => {
-    // Cleanup test sessions
+    // Cleanup test sessions and run artifacts
     try {
       const files = await fs.readdir(sessionsDir);
       for (const file of files) {
         if (file.endsWith('.json')) {
           const sessionId = file.replace('.json', '');
           await manager.deleteSession(sessionId);
+        }
+
+        if (file.endsWith('.run.jsonl')) {
+          await fs.unlink(join(sessionsDir, file));
+        }
+
+        if (file.endsWith('.artifacts')) {
+          await fs.rm(join(sessionsDir, file), { recursive: true, force: true });
         }
       }
     } catch {
@@ -33,6 +41,7 @@ describe('SessionManager', () => {
     expect(session.sessionId).toBeDefined();
     expect(session.workspaceRoot).toBe('/test/workspace');
     expect(session.createdAt).toBeGreaterThan(0);
+    expect(session.runStatus).toBe('idle');
   });
 
   it('should load a saved session', async () => {
@@ -60,12 +69,33 @@ describe('SessionManager', () => {
   it('should update lastActivity on save', async () => {
     const session = await manager.createSession('/test/workspace');
     const originalActivity = session.lastActivity;
-    
+
     // Wait a bit to ensure timestamp changes
     await new Promise(r => setTimeout(r, 10));
-    
+
     await manager.saveSession(session);
     const updated = await manager.loadSession(session.sessionId);
     expect(updated?.lastActivity).toBeGreaterThanOrEqual(originalActivity);
+  });
+
+  it('should persist run start, heartbeat, and completion metadata', async () => {
+    const session = await manager.createSession('/test/workspace');
+
+    await manager.markRunStarted(session, 'ship feature', 'plan+act');
+    expect(session.currentRun).toBeDefined();
+    expect(session.runStatus).toBe('running');
+
+    await manager.markRunHeartbeat(session, { stage: 'plan' });
+    await manager.markRunFinished(session, 'completed', { summary: 'ok' });
+
+    const loaded = await manager.loadSession(session.sessionId);
+    expect(loaded?.runStatus).toBe('completed');
+    expect(loaded?.currentRun).toBeUndefined();
+    expect((loaded?.runHistory?.length ?? 0) > 0).toBe(true);
+
+    const runLog = await fs.readFile(join(sessionsDir, `${session.sessionId}.run.jsonl`), 'utf-8');
+    expect(runLog).toContain('run_started');
+    expect(runLog).toContain('heartbeat');
+    expect(runLog).toContain('run_finished');
   });
 });

--- a/packages/valor-cli/src/SessionManager.ts
+++ b/packages/valor-cli/src/SessionManager.ts
@@ -7,7 +7,7 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { v4 as uuidv4 } from 'uuid';
-import { SessionConfig, InstanceInfo } from './types';
+import { SessionConfig, InstanceInfo, SessionRunStatus } from './types';
 
 export class SessionManager {
   private sessionsDir: string;
@@ -32,6 +32,8 @@ export class SessionManager {
       workspaceRoot,
       createdAt: now,
       lastActivity: now,
+      runStatus: 'idle',
+      runHistory: [],
     };
 
     await this.saveSession(config);
@@ -39,16 +41,19 @@ export class SessionManager {
   }
 
   async saveSession(config: SessionConfig): Promise<void> {
-    const path = join(this.sessionsDir, `${config.sessionId}.json`);
+    const path = this.getSessionPath(config.sessionId);
     config.lastActivity = Date.now();
     await fs.writeFile(path, JSON.stringify(config, null, 2));
   }
 
   async loadSession(sessionId: string): Promise<SessionConfig | null> {
     try {
-      const path = join(this.sessionsDir, `${sessionId}.json`);
+      const path = this.getSessionPath(sessionId);
       const content = await fs.readFile(path, 'utf-8');
-      return JSON.parse(content) as SessionConfig;
+      const loaded = JSON.parse(content) as SessionConfig;
+      loaded.runStatus = loaded.runStatus ?? (loaded.taskId ? 'running' : 'idle');
+      loaded.runHistory = loaded.runHistory ?? [];
+      return loaded;
     } catch {
       return null;
     }
@@ -68,7 +73,7 @@ export class SessionManager {
               sessionId: config.sessionId,
               workspaceRoot: config.workspaceRoot,
               taskId: config.taskId,
-              status: config.taskId ? 'active' : 'idle',
+              status: this.toInstanceStatus(config.runStatus, config.taskId),
               createdAt: config.createdAt,
               lastActivity: config.lastActivity,
             });
@@ -82,12 +87,116 @@ export class SessionManager {
     }
   }
 
+  async markRunStarted(session: SessionConfig, description: string, mode: 'plan' | 'act' | 'plan+act'): Promise<void> {
+    const now = Date.now();
+    session.runStatus = 'running';
+    session.taskId = session.sessionId;
+    session.currentRun = {
+      runId: uuidv4(),
+      description,
+      mode,
+      startedAt: now,
+      updatedAt: now,
+      heartbeatAt: now,
+      status: 'running',
+      eventsPath: this.getSessionEventsPath(session.sessionId),
+      artifactsDir: this.getSessionArtifactsDir(session.sessionId),
+    };
+
+    await fs.mkdir(session.currentRun.artifactsDir, { recursive: true });
+    await this.appendRunEvent(session.sessionId, {
+      type: 'run_started',
+      at: now,
+      mode,
+      description,
+      runId: session.currentRun.runId,
+    });
+    await this.saveSession(session);
+  }
+
+  async markRunHeartbeat(session: SessionConfig, data?: Record<string, unknown>): Promise<void> {
+    if (!session.currentRun) {
+      return;
+    }
+
+    const now = Date.now();
+    session.currentRun.updatedAt = now;
+    session.currentRun.heartbeatAt = now;
+
+    await this.appendRunEvent(session.sessionId, {
+      type: 'heartbeat',
+      at: now,
+      runId: session.currentRun.runId,
+      ...(data ?? {}),
+    });
+    await this.saveSession(session);
+  }
+
+  async markRunFinished(
+    session: SessionConfig,
+    status: Exclude<SessionRunStatus, 'running' | 'idle'>,
+    summary?: Record<string, unknown>
+  ): Promise<void> {
+    if (!session.currentRun) {
+      return;
+    }
+
+    const now = Date.now();
+    const finishedRun = {
+      ...session.currentRun,
+      updatedAt: now,
+      status,
+    };
+
+    await this.appendRunEvent(session.sessionId, {
+      type: 'run_finished',
+      at: now,
+      runId: session.currentRun.runId,
+      status,
+      ...(summary ?? {}),
+    });
+
+    session.runStatus = status;
+    session.taskId = undefined;
+    session.currentRun = undefined;
+    session.runHistory = [...(session.runHistory ?? []), finishedRun].slice(-20);
+
+    await this.saveSession(session);
+  }
+
   async deleteSession(sessionId: string): Promise<void> {
     try {
-      const path = join(this.sessionsDir, `${sessionId}.json`);
+      const path = this.getSessionPath(sessionId);
       await fs.unlink(path);
     } catch (error) {
       throw new Error(`Failed to delete session: ${error}`);
     }
+  }
+
+  private getSessionPath(sessionId: string): string {
+    return join(this.sessionsDir, `${sessionId}.json`);
+  }
+
+  private getSessionEventsPath(sessionId: string): string {
+    return join(this.sessionsDir, `${sessionId}.run.jsonl`);
+  }
+
+  private getSessionArtifactsDir(sessionId: string): string {
+    return join(this.sessionsDir, `${sessionId}.artifacts`);
+  }
+
+  private async appendRunEvent(sessionId: string, payload: Record<string, unknown>): Promise<void> {
+    const line = `${JSON.stringify(payload)}\n`;
+    await fs.appendFile(this.getSessionEventsPath(sessionId), line, 'utf-8');
+  }
+
+  private toInstanceStatus(runStatus: SessionRunStatus | undefined, taskId?: string): InstanceInfo['status'] {
+    if (runStatus === 'running' || taskId) {
+      return 'active';
+    }
+    if (runStatus === 'completed' || runStatus === 'failed' || runStatus === 'cancelled' || runStatus === 'timed_out') {
+      return 'completed';
+    }
+    return 'idle';
   }
 }

--- a/packages/valor-cli/src/commands/TaskCommand.ts
+++ b/packages/valor-cli/src/commands/TaskCommand.ts
@@ -6,9 +6,6 @@ import chalk from 'chalk';
 import ora from 'ora';
 import { SessionManager } from '../SessionManager';
 import { Orchestrator, OrchestrationContext } from '../orchestrator/Orchestrator';
-import { promises as fs } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
 
 export class TaskCommand {
   private sessionManager: SessionManager;
@@ -19,12 +16,12 @@ export class TaskCommand {
 
   async execute(description: string, options: any): Promise<void> {
     const { plan = false, act = false, session: sessionId } = options;
+    let session: any;
 
     try {
       await this.sessionManager.initialize();
 
       // Create or attach to session
-      let session: any;
       if (sessionId) {
         session = await this.sessionManager.loadSession(sessionId);
         if (!session) {
@@ -38,6 +35,9 @@ export class TaskCommand {
       console.log(chalk.cyan(`\n📋 Task: ${description}`));
       console.log(chalk.gray(`Session: ${session.sessionId}\n`));
 
+      const mode: 'plan' | 'act' | 'plan+act' = plan ? 'plan' : act ? 'act' : 'plan+act';
+      await this.sessionManager.markRunStarted(session, description, mode);
+
       if (plan) {
         await this.runPlanMode(description, session);
       } else if (act) {
@@ -49,10 +49,14 @@ export class TaskCommand {
         await this.runActMode(description, session);
       }
 
-      // Save session
-      await this.sessionManager.saveSession(session);
+      await this.sessionManager.markRunFinished(session, 'completed');
       console.log(chalk.green('\n✅ Task complete\n'));
     } catch (error) {
+      if (session) {
+        await this.sessionManager.markRunFinished(session, 'failed', {
+          error: String(error),
+        });
+      }
       console.error(chalk.red(`\n❌ Error: ${error}\n`));
       process.exit(1);
     }
@@ -80,6 +84,11 @@ export class TaskCommand {
       // Log to ledger
       const ledger = orchestrator.getLedger();
       const entries = await ledger.readAll();
+
+      await this.sessionManager.markRunHeartbeat(session, {
+        stage: 'plan',
+        ledgerEntries: entries.length,
+      });
 
       spinner.succeed(chalk.green('Plan generated'));
       console.log(
@@ -112,6 +121,14 @@ export class TaskCommand {
       await orchestrator.initialize();
 
       const result = await orchestrator.execute();
+      await this.sessionManager.markRunHeartbeat(session, {
+        stage: 'act',
+        status: result.status,
+        turns: result.turn,
+        tokens: result.totalTokens,
+        cost: Number(result.totalCost.toFixed(4)),
+        ledgerEntries: result.ledgerEntries,
+      });
 
       spinner.succeed(chalk.green('Task executed'));
       console.log(chalk.gray(`Status: ${result.status}`));

--- a/packages/valor-cli/src/types.ts
+++ b/packages/valor-cli/src/types.ts
@@ -3,6 +3,20 @@
  * Defines interfaces for CLI operations, session persistence, and checkpoints
  */
 
+export type SessionRunStatus = 'idle' | 'running' | 'completed' | 'failed' | 'cancelled' | 'timed_out';
+
+export interface SessionRunSummary {
+  runId: string;
+  description: string;
+  mode: 'plan' | 'act' | 'plan+act';
+  startedAt: number;
+  updatedAt: number;
+  heartbeatAt: number;
+  status: Exclude<SessionRunStatus, 'idle'>;
+  eventsPath: string;
+  artifactsDir: string;
+}
+
 export interface SessionConfig {
   sessionId: string;
   workspaceRoot: string;
@@ -11,6 +25,9 @@ export interface SessionConfig {
   modelId?: string;
   createdAt: number;
   lastActivity: number;
+  runStatus?: SessionRunStatus;
+  currentRun?: SessionRunSummary;
+  runHistory?: SessionRunSummary[];
 }
 
 export interface TaskRunOptions {

--- a/src/services/remote-coding/RemoteCodingSessionStore.test.ts
+++ b/src/services/remote-coding/RemoteCodingSessionStore.test.ts
@@ -1,0 +1,65 @@
+import fs from "fs"
+import os from "os"
+import path from "path"
+import { afterEach, describe, expect, it } from "vitest"
+import { RemoteCodingSessionStore } from "./RemoteCodingSessionStore"
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop()
+		if (dir && fs.existsSync(dir)) {
+			fs.rmSync(dir, { recursive: true, force: true })
+		}
+	}
+})
+
+describe("RemoteCodingSessionStore", () => {
+	it("starts sessions and prepares deterministic log/artifact paths", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "valoride-remote-session-"))
+		tempDirs.push(root)
+
+		const store = new RemoteCodingSessionStore(root)
+		const now = new Date("2026-03-03T20:06:00.000Z")
+		const session = store.startSession({
+			sessionId: "session-1",
+			task: "Implement detached run mode",
+			repoPath: "/tmp/repo",
+			now,
+		})
+
+		expect(session.status).toBe("running")
+		expect(fs.existsSync(session.logPath)).toBe(true)
+		expect(fs.existsSync(session.artifactsPath)).toBe(true)
+		expect(session.createdAt).toBe(now.toISOString())
+		expect(store.listSessions().map((s) => s.id)).toEqual(["session-1"])
+	})
+
+	it("updates heartbeat, appends logs, and supports stop/timeout controls", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "valoride-remote-session-"))
+		tempDirs.push(root)
+
+		const store = new RemoteCodingSessionStore(root)
+		store.startSession({
+			sessionId: "session-2",
+			task: "Run codegen",
+			repoPath: "/tmp/repo",
+			now: new Date("2026-03-03T20:06:00.000Z"),
+		})
+
+		const heartbeat = store.updateHeartbeat("session-2", "still running", new Date("2026-03-03T20:07:00.000Z"))
+		expect(heartbeat?.lastHeartbeatMessage).toBe("still running")
+
+		expect(store.appendLog("session-2", "build passed")).toBe(true)
+		expect(fs.readFileSync(heartbeat!.logPath, "utf8")).toContain("build passed")
+
+		const stopped = store.stopSession("session-2", new Date("2026-03-03T20:08:00.000Z"))
+		expect(stopped?.status).toBe("stopped")
+		expect(stopped?.endedAt).toBe("2026-03-03T20:08:00.000Z")
+
+		const timedOut = store.markTimedOut("session-2", new Date("2026-03-03T20:09:00.000Z"), "worker heartbeat expired")
+		expect(timedOut?.status).toBe("timed_out")
+		expect(timedOut?.errorMessage).toBe("worker heartbeat expired")
+	})
+})

--- a/src/services/remote-coding/RemoteCodingSessionStore.ts
+++ b/src/services/remote-coding/RemoteCodingSessionStore.ts
@@ -1,0 +1,116 @@
+import fs from "fs"
+import path from "path"
+import { randomUUID } from "crypto"
+
+export type RemoteCodingSessionStatus = "running" | "stopping" | "stopped" | "failed" | "timed_out"
+
+export interface RemoteCodingSessionRecord {
+	id: string
+	task: string
+	repoPath: string
+	createdAt: string
+	updatedAt: string
+	startedAt: string
+	endedAt?: string
+	status: RemoteCodingSessionStatus
+	heartbeatAt: string
+	lastHeartbeatMessage?: string
+	logPath: string
+	artifactsPath: string
+	errorMessage?: string
+}
+
+export interface StartRemoteCodingSessionInput {
+	task: string
+	repoPath: string
+	sessionId?: string
+	now?: Date
+}
+
+export class RemoteCodingSessionStore {
+	private readonly sessions = new Map<string, RemoteCodingSessionRecord>()
+
+	constructor(private readonly baseDir: string) {
+		fs.mkdirSync(this.baseDir, { recursive: true })
+	}
+
+	startSession(input: StartRemoteCodingSessionInput): RemoteCodingSessionRecord {
+		const now = input.now ?? new Date()
+		const sessionId = input.sessionId ?? randomUUID()
+		const sessionDir = path.join(this.baseDir, sessionId)
+		const artifactsPath = path.join(sessionDir, "artifacts")
+		const logPath = path.join(sessionDir, "run.log")
+
+		fs.mkdirSync(artifactsPath, { recursive: true })
+		if (!fs.existsSync(logPath)) {
+			fs.writeFileSync(logPath, "", "utf8")
+		}
+
+		const record: RemoteCodingSessionRecord = {
+			id: sessionId,
+			task: input.task,
+			repoPath: input.repoPath,
+			createdAt: now.toISOString(),
+			updatedAt: now.toISOString(),
+			startedAt: now.toISOString(),
+			status: "running",
+			heartbeatAt: now.toISOString(),
+			logPath,
+			artifactsPath,
+		}
+
+		this.sessions.set(sessionId, record)
+		return record
+	}
+
+	listSessions(): RemoteCodingSessionRecord[] {
+		return [...this.sessions.values()].sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+	}
+
+	updateHeartbeat(sessionId: string, message?: string, now: Date = new Date()): RemoteCodingSessionRecord | null {
+		const session = this.sessions.get(sessionId)
+		if (!session) {
+			return null
+		}
+
+		session.heartbeatAt = now.toISOString()
+		session.updatedAt = now.toISOString()
+		session.lastHeartbeatMessage = message
+		this.sessions.set(sessionId, session)
+		return session
+	}
+
+	appendLog(sessionId: string, line: string): boolean {
+		const session = this.sessions.get(sessionId)
+		if (!session) {
+			return false
+		}
+		fs.appendFileSync(session.logPath, `${line}\n`, "utf8")
+		return true
+	}
+
+	stopSession(sessionId: string, now: Date = new Date()): RemoteCodingSessionRecord | null {
+		const session = this.sessions.get(sessionId)
+		if (!session) {
+			return null
+		}
+		session.status = "stopped"
+		session.endedAt = now.toISOString()
+		session.updatedAt = now.toISOString()
+		this.sessions.set(sessionId, session)
+		return session
+	}
+
+	markTimedOut(sessionId: string, now: Date = new Date(), message: string = "session timed out"): RemoteCodingSessionRecord | null {
+		const session = this.sessions.get(sessionId)
+		if (!session) {
+			return null
+		}
+		session.status = "timed_out"
+		session.errorMessage = message
+		session.endedAt = now.toISOString()
+		session.updatedAt = now.toISOString()
+		this.sessions.set(sessionId, session)
+		return session
+	}
+}


### PR DESCRIPTION
## Summary\n- add a first-pass  for detached coding runs\n- support start/list/heartbeat/log append/stop/timeout controls\n- persist per-session run log + artifacts directory for auditability\n- add focused unit tests covering deterministic path prep and lifecycle transitions\n\n## Validation\n- yarn run v1.22.22
$ /Users/valklaw/.openclaw/workspace/repos/ValorIDE-laneA-10run/node_modules/.bin/vitest run src/services/remote-coding/RemoteCodingSessionStore.test.ts

 RUN  v3.2.4 /Users/valklaw/.openclaw/workspace/repos/ValorIDE-laneA-10run

 ✓ src/services/remote-coding/RemoteCodingSessionStore.test.ts (2 tests) 8ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  20:15:58
   Duration  535ms (transform 54ms, setup 0ms, collect 42ms, tests 8ms, environment 0ms, prepare 106ms)

Done in 1.53s.\n- yarn run v1.22.22
$ tsc --noEmit
Done in 80.31s.\n\nCloses #10\n\n@codex review this PR for detached-session API shape and persistence semantics.