### PR TITLE
feat(tool-relay): add allowlisted tool-user command lane result cards

### DIFF
--- a/src/services/communication/ToolRelayService.ts
+++ b/src/services/communication/ToolRelayService.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import { exec } from "child_process";
 import { cwd } from "../../core/task";
 import { searchWorkspaceFiles } from "../../services/search/file-search";
+import { isAllowedCommand, loadCommandAllowlist, loadToolAllowlist, toResultCard } from "./toolUserLane";
 
 export interface ToolCommand {
   type: "tool_command";
@@ -25,26 +26,26 @@ export interface ToolResult {
   senderId: string;
 }
 
+
 /**
  * ToolRelayService enables remote control by relaying tool commands over websocket.
  * When ValorIDE executes a tool locally, it can also send that command to remote instances.
  * When it receives a tool command from a remote instance, it executes it locally.
  */
 export class ToolRelayService {
-  private pendingCommands = new Map<
-    string,
-    {
-      resolve: (result: any) => void;
-      reject: (error: Error) => void;
-      timestamp: number;
-    }
-  >();
-
+  private pendingCommands = new Map<string, {
+    resolve: (result: any) => void;
+    reject: (error: Error) => void;
+    timestamp: number;
+  }>();
+  
   private commandTimeout = 30000; // 30 seconds
+  private readonly allowedTools = loadToolAllowlist(process.env.VALORIDE_TOOL_ALLOWLIST);
+  private readonly commandAllowlist = loadCommandAllowlist(process.env.VALORIDE_TOOL_COMMAND_ALLOWLIST);
 
   constructor(
     private communicationService: CommunicationService,
-    private controller: Controller,
+    private controller: Controller
   ) {
     this.setupMessageHandlers();
     this.startTimeoutCleanup();
@@ -54,7 +55,7 @@ export class ToolRelayService {
     this.communicationService.on("message", (message: any) => {
       try {
         const payload = JSON.parse(message.payload || "{}");
-
+        
         if (payload.type === "tool_command") {
           this.handleIncomingToolCommand(payload as ToolCommand);
         } else if (payload.type === "tool_result") {
@@ -69,10 +70,7 @@ export class ToolRelayService {
   /**
    * Send a tool command to remote ValorIDE instances
    */
-  async sendToolCommand(
-    toolName: string,
-    parameters: Record<string, any>,
-  ): Promise<any> {
+  async sendToolCommand(toolName: string, parameters: Record<string, any>): Promise<any> {
     if (!this.communicationService.ready) {
       throw new Error("Communication service not ready");
     }
@@ -84,7 +82,7 @@ export class ToolRelayService {
       parameters,
       commandId,
       timestamp: Date.now(),
-      senderId: this.getSenderId(),
+      senderId: this.getSenderId()
     };
 
     // Send command over websocket
@@ -95,7 +93,7 @@ export class ToolRelayService {
       this.pendingCommands.set(commandId, {
         resolve,
         reject,
-        timestamp: Date.now(),
+        timestamp: Date.now()
       });
 
       // Set up timeout
@@ -113,56 +111,37 @@ export class ToolRelayService {
    * Handle incoming tool command from remote ValorIDE instance
    */
   private async handleIncomingToolCommand(command: ToolCommand) {
-    console.log(
-      `ToolRelayService: Executing remote tool command: ${command.toolName}`,
-    );
+    console.log(`ToolRelayService: Executing remote tool command: ${command.toolName}`);
 
     try {
+      if (!this.allowedTools.has(command.toolName)) {
+        throw new Error(`Tool command not allowed: ${command.toolName}`);
+      }
+
       let result: any;
 
       // Execute the tool command using the controller's existing methods
       switch (command.toolName) {
         case "read_file":
-          result = await this.executeReadFile(
-            command.parameters as { path: string },
-          );
+          result = await this.executeReadFile(command.parameters as { path: string });
           break;
         case "write_to_file":
-          result = await this.executeWriteToFile(
-            command.parameters as { path: string; content: string },
-          );
+          result = await this.executeWriteToFile(command.parameters as { path: string; content: string });
           break;
         case "replace_in_file":
-          result = await this.executeReplaceInFile(
-            command.parameters as { path: string; diff: string },
-          );
+          result = await this.executeReplaceInFile(command.parameters as { path: string; diff: string });
           break;
         case "execute_command":
-          result = await this.executeCommand(
-            command.parameters as {
-              command: string;
-              requires_approval?: boolean;
-            },
-          );
+          result = await this.executeCommand(command.parameters as { command: string; requires_approval?: boolean });
           break;
         case "list_files":
-          result = await this.executeListFiles(
-            command.parameters as { path: string; recursive?: boolean },
-          );
+          result = await this.executeListFiles(command.parameters as { path: string; recursive?: boolean });
           break;
         case "search_files":
-          result = await this.executeSearchFiles(
-            command.parameters as {
-              path: string;
-              regex: string;
-              file_pattern?: string;
-            },
-          );
+          result = await this.executeSearchFiles(command.parameters as { path: string; regex: string; file_pattern?: string });
           break;
         case "list_code_definition_names":
-          result = await this.executeListCodeDefinitionNames(
-            command.parameters as { path: string },
-          );
+          result = await this.executeListCodeDefinitionNames(command.parameters as { path: string });
           break;
         case "browser_action":
           result = await this.executeBrowserAction(command.parameters);
@@ -171,13 +150,11 @@ export class ToolRelayService {
           throw new Error(`Unknown tool command: ${command.toolName}`);
       }
 
-      // Send successful result back
-      this.sendToolResult(command.commandId, true, result);
+      // Send successful result back as a structured card payload
+      this.sendToolResult(command.commandId, true, toResultCard(command.toolName, result));
+      
     } catch (error: any) {
-      console.error(
-        `ToolRelayService: Error executing ${command.toolName}:`,
-        error,
-      );
+      console.error(`ToolRelayService: Error executing ${command.toolName}:`, error);
       // Send error result back
       this.sendToolResult(command.commandId, false, undefined, error.message);
     }
@@ -190,7 +167,7 @@ export class ToolRelayService {
     const pending = this.pendingCommands.get(result.commandId);
     if (pending) {
       this.pendingCommands.delete(result.commandId);
-
+      
       if (result.success) {
         pending.resolve(result.result);
       } else {
@@ -202,12 +179,7 @@ export class ToolRelayService {
   /**
    * Send a tool result back to the sender
    */
-  private sendToolResult(
-    commandId: string,
-    success: boolean,
-    result?: any,
-    error?: string,
-  ) {
+  private sendToolResult(commandId: string, success: boolean, result?: any, error?: string) {
     const toolResult: ToolResult = {
       type: "tool_result",
       commandId,
@@ -215,7 +187,7 @@ export class ToolRelayService {
       result,
       error,
       timestamp: Date.now(),
-      senderId: this.getSenderId(),
+      senderId: this.getSenderId()
     };
 
     this.communicationService.sendMessage("valoride:tool_result", toolResult);
@@ -228,59 +200,49 @@ export class ToolRelayService {
     return await fs.readFile(filePath, "utf8");
   }
 
-  private async executeWriteToFile(params: {
-    path: string;
-    content: string;
-  }): Promise<void> {
+  private async executeWriteToFile(params: { path: string; content: string }): Promise<void> {
     const filePath = path.resolve(cwd, params.path);
-
+    
     // Create directories if needed
     await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, params.content, "utf8");
   }
 
-  private async executeReplaceInFile(params: {
-    path: string;
-    diff: string;
-  }): Promise<void> {
+  private async executeReplaceInFile(params: { path: string; diff: string }): Promise<void> {
     // This would integrate with the existing replace_in_file implementation
     // For now, we'll implement a simplified version
     const filePath = path.resolve(cwd, params.path);
     const content = await fs.readFile(filePath, "utf8");
-
+    
     // Parse and apply the diff (this is a simplified implementation)
     // In reality, you'd want to use the existing diff parsing logic
     const modifiedContent = this.applyDiff(content, params.diff);
     await fs.writeFile(filePath, modifiedContent, "utf8");
   }
 
-  private async executeCommand(params: {
-    command: string;
-    requires_approval?: boolean;
-  }): Promise<string> {
+  private async executeCommand(params: { command: string; requires_approval?: boolean }): Promise<{ stdout: string; stderr: string; command: string }> {
+    if (!isAllowedCommand(params.command, this.commandAllowlist)) {
+      throw new Error(`Command blocked by allowlist: ${params.command}`);
+    }
+
     return new Promise((resolve, reject) => {
-      exec(
-        params.command,
-        { cwd },
-        (error: any, stdout: string, stderr: string) => {
-          if (error) {
-            reject(
-              new Error(`Command failed: ${error.message}\nstderr: ${stderr}`),
-            );
-          } else {
-            resolve(stdout || stderr || "Command executed successfully");
-          }
-        },
-      );
+      exec(params.command, { cwd }, (error: any, stdout: string, stderr: string) => {
+        if (error) {
+          reject(new Error(`Command failed: ${error.message}\nstderr: ${stderr}`));
+        } else {
+          resolve({
+            command: params.command,
+            stdout: stdout?.trim() || "",
+            stderr: stderr?.trim() || ""
+          });
+        }
+      });
     });
   }
 
-  private async executeListFiles(params: {
-    path: string;
-    recursive?: boolean;
-  }): Promise<string[]> {
+  private async executeListFiles(params: { path: string; recursive?: boolean }): Promise<string[]> {
     const dirPath = path.resolve(cwd, params.path);
-
+    
     if (params.recursive) {
       return await this.listFilesRecursive(dirPath);
     } else {
@@ -289,32 +251,21 @@ export class ToolRelayService {
     }
   }
 
-  private async executeSearchFiles(params: {
-    path: string;
-    regex: string;
-    file_pattern?: string;
-  }): Promise<any> {
+  private async executeSearchFiles(params: { path: string; regex: string; file_pattern?: string }): Promise<any> {
     // This would integrate with existing search functionality
     return await searchWorkspaceFiles(params.regex, params.path, 100);
   }
 
-  private async executeListCodeDefinitionNames(params: {
-    path: string;
-  }): Promise<any> {
+  private async executeListCodeDefinitionNames(params: { path: string }): Promise<any> {
     // This would integrate with existing code definition listing functionality
     // For now, return a placeholder
-    return {
-      message:
-        "Code definitions listing not yet implemented in remote execution",
-    };
+    return { message: "Code definitions listing not yet implemented in remote execution" };
   }
 
   private async executeBrowserAction(params: any): Promise<any> {
     // This would integrate with existing browser automation
     // For now, return a placeholder
-    return {
-      message: "Browser actions not yet implemented in remote execution",
-    };
+    return { message: "Browser actions not yet implemented in remote execution" };
   }
 
   // Helper methods
@@ -331,57 +282,53 @@ export class ToolRelayService {
   private applyDiff(content: string, diff: string): string {
     // This is a simplified diff application - you'd want to use the existing
     // replace_in_file logic from the main codebase
-    const lines = content.split("\n");
+    const lines = content.split('\n');
     const blocks = this.parseDiffBlocks(diff);
-
+    
     for (const block of blocks) {
-      const searchLines = block.search.split("\n");
-      const replaceLines = block.replace.split("\n");
-
+      const searchLines = block.search.split('\n');
+      const replaceLines = block.replace.split('\n');
+      
       // Find and replace (simplified - real implementation would be more robust)
-      const searchStart = lines.findIndex((line) =>
-        line.includes(searchLines[0]),
-      );
+      const searchStart = lines.findIndex(line => line.includes(searchLines[0]));
       if (searchStart !== -1) {
         lines.splice(searchStart, searchLines.length, ...replaceLines);
       }
     }
-
-    return lines.join("\n");
+    
+    return lines.join('\n');
   }
 
-  private parseDiffBlocks(
-    diff: string,
-  ): Array<{ search: string; replace: string }> {
+  private parseDiffBlocks(diff: string): Array<{ search: string; replace: string }> {
     // Parse SEARCH/REPLACE blocks - simplified implementation
     const blocks = [];
     const regex = /<<<<<<< SEARCH\n(.*?)\n=======\n(.*?)\n>>>>>>> REPLACE/gs;
     let match;
-
+    
     while ((match = regex.exec(diff)) !== null) {
       blocks.push({
         search: match[1],
-        replace: match[2],
+        replace: match[2]
       });
     }
-
+    
     return blocks;
   }
 
   private async listFilesRecursive(dirPath: string): Promise<string[]> {
     const files: string[] = [];
     const entries = await fs.readdir(dirPath, { withFileTypes: true });
-
+    
     for (const entry of entries) {
       const fullPath = path.join(dirPath, entry.name);
       if (entry.isDirectory()) {
         const subFiles = await this.listFilesRecursive(fullPath);
-        files.push(...subFiles.map((f) => path.join(entry.name, f)));
+        files.push(...subFiles.map(f => path.join(entry.name, f)));
       } else {
         files.push(entry.name);
       }
     }
-
+    
     return files;
   }
 

--- a/src/services/communication/toolUserLane.test.ts
+++ b/src/services/communication/toolUserLane.test.ts
@@ -1,0 +1,22 @@
+import { isAllowedCommand, loadCommandAllowlist, loadToolAllowlist, toResultCard } from "./toolUserLane";
+
+describe("toolUserLane", () => {
+  it("loads explicit tool allowlist", () => {
+    const tools = loadToolAllowlist("read_file,execute_command");
+    expect(tools.has("read_file")).toBe(true);
+    expect(tools.has("write_to_file")).toBe(false);
+  });
+
+  it("blocks commands outside regex allowlist", () => {
+    const patterns = loadCommandAllowlist("^yarn\\b,^node\\b");
+    expect(isAllowedCommand("yarn test", patterns)).toBe(true);
+    expect(isAllowedCommand("rm -rf /", patterns)).toBe(false);
+  });
+
+  it("returns structured execute_command card", () => {
+    const card = toResultCard("execute_command", { command: "yarn test", stdout: "ok", stderr: "" });
+    expect(card.summary).toBe("ok");
+    expect(card.logs[0]).toBe("$ yarn test");
+    expect(card.artifacts).toEqual([]);
+  });
+});

--- a/src/services/communication/toolUserLane.ts
+++ b/src/services/communication/toolUserLane.ts
@@ -1,0 +1,53 @@
+export interface ToolExecutionResultCard {
+  toolName: string;
+  summary: string;
+  logs: string[];
+  artifacts: string[];
+  output?: string;
+}
+
+export function loadToolAllowlist(envValue?: string): Set<string> {
+  const configured = envValue?.split(",").map(v => v.trim()).filter(Boolean);
+  const defaults = ["read_file", "write_to_file", "replace_in_file", "list_files", "search_files", "list_code_definition_names", "browser_action", "execute_command"];
+  return new Set(configured?.length ? configured : defaults);
+}
+
+export function loadCommandAllowlist(envValue?: string): RegExp[] {
+  const configured = envValue
+    ?.split(",")
+    .map(v => v.trim())
+    .filter(Boolean)
+    .map(pattern => new RegExp(pattern));
+
+  return configured?.length ? configured : [/^yarn\b/, /^npm\b/, /^pnpm\b/, /^node\b/, /^git\b/, /^ls\b/, /^cat\b/, /^echo\b/];
+}
+
+export function isAllowedCommand(command: string, patterns: RegExp[]): boolean {
+  return patterns.some(pattern => pattern.test(command));
+}
+
+export function toResultCard(toolName: string, rawResult: any): ToolExecutionResultCard {
+  if (toolName === "execute_command" && rawResult && typeof rawResult === "object") {
+    const stdout = typeof rawResult.stdout === "string" ? rawResult.stdout : "";
+    const stderr = typeof rawResult.stderr === "string" ? rawResult.stderr : "";
+    const logs = [rawResult.command ? `$ ${rawResult.command}` : "", stdout, stderr].filter(Boolean);
+
+    return {
+      toolName,
+      summary: stdout || stderr || "Command executed successfully",
+      logs,
+      artifacts: [],
+      output: stdout || stderr || ""
+    };
+  }
+
+  const summary = typeof rawResult === "string" ? rawResult : rawResult?.message || "Tool command executed";
+
+  return {
+    toolName,
+    summary,
+    logs: [summary],
+    artifacts: [],
+    output: typeof rawResult === "string" ? rawResult : JSON.stringify(rawResult)
+  };
+}


### PR DESCRIPTION
## Summary
- add a dedicated tool-user lane helper (`toolUserLane.ts`) for permission-gated tool allowlists and command regex allowlists
- enforce allowlist checks in `ToolRelayService` before executing remote tool commands
- return structured result-card payloads (summary/logs/artifacts/output) so UI can render consistent tool execution cards

## Validation
- `npx jest src/services/communication/toolUserLane.test.ts --runInBand` ✅
- `yarn check-types` ❌ blocked by existing repo baseline dependency/type issues (`antd` and `@ant-design/icons` missing in `webview-ui/src/components/SwarmPanel2/*`)

Closes #11

@codex please review allowlist defaults, regex guardrails, and card payload shape.
