### PR TITLE
feat(command-protocol): add versioned widget pop-in actions (#13)

### DIFF
--- a/webview-ui/src/utils/commandProcessor.js
+++ b/webview-ui/src/utils/commandProcessor.js
@@ -27,6 +27,8 @@ export class FrontendCommandProcessor {
     processedContent = await this.processNavigationCommands(processedContent);
     // Process UI interaction commands
     processedContent = await this.processUICommands(processedContent);
+    // Process versioned widget actions
+    processedContent = await this.processWidgetCommands(processedContent);
     return processedContent;
   }
   /**
@@ -156,6 +158,42 @@ export class FrontendCommandProcessor {
         processedContent = processedContent.replace(
           match[0],
           `[UI action failed: ${error}]`
+        );
+      }
+    }
+    return processedContent;
+  }
+  /**
+   * Handle versioned widget actions.
+   */
+  async processWidgetCommands(content) {
+    const widgetRegex =
+      /<widget_action>\s*<version>([\s\S]*?)<\/version>\s*<phase>([\s\S]*?)<\/phase>\s*<widget>([\s\S]*?)<\/widget>(?:\s*<payload>([\s\S]*?)<\/payload>)?\s*<\/widget_action>/g;
+    let processedContent = content;
+    let match;
+    while ((match = widgetRegex.exec(content)) !== null) {
+      try {
+        const version = match[1].trim();
+        const phase = match[2].trim().toLowerCase();
+        const widgetType = match[3].trim();
+        const payloadRaw = match[4]?.trim();
+        const payload = payloadRaw ? JSON.parse(payloadRaw) : {};
+        const result = await this.executeWidgetAction({
+          version,
+          phase,
+          widgetType,
+          payload,
+        });
+        processedContent = processedContent.replace(
+          match[0],
+          result.success
+            ? `[widget:${phase}:${widgetType}]`
+            : `[Widget action failed: ${result.error}]`
+        );
+      } catch (error) {
+        processedContent = processedContent.replace(
+          match[0],
+          `[Widget action failed: ${error}]`
         );
       }
     }
@@ -293,6 +331,35 @@ export class FrontendCommandProcessor {
     } catch (error) {
       return { success: false, error: `UI action failed: ${error}` };
     }
+  }
+  async executeWidgetAction({ version, phase, widgetType, payload }) {
+    if (version !== "1") {
+      return {
+        success: false,
+        error: `Unsupported widget action version: ${version}`,
+      };
+    }
+    if (phase !== "open" && phase !== "configure" && phase !== "submit") {
+      return {
+        success: false,
+        error: `Unsupported widget phase: ${phase}`,
+      };
+    }
+    const detail = {
+      kind: "widget_command",
+      phase,
+      widgetType,
+      version,
+      timestamp: new Date().toISOString(),
+      payload,
+    };
+    window.dispatchEvent(new CustomEvent("valoride:widget-action", { detail }));
+    this.context.telemetryHook?.(detail);
+    return {
+      success: true,
+      data: detail,
+      message: `Widget ${phase} dispatched for ${widgetType}`,
+    };
   }
 }
 /**

--- a/webview-ui/src/utils/commandProcessor.test.ts
+++ b/webview-ui/src/utils/commandProcessor.test.ts
@@ -1,0 +1,38 @@
+import { FrontendCommandProcessor } from "./commandProcessor";
+
+describe("FrontendCommandProcessor widget actions", () => {
+  it("dispatches versioned widget open events and telemetry hook", async () => {
+    const telemetryHook = jest.fn();
+    const eventSpy = jest.fn();
+    window.addEventListener("valoride:widget-action", eventSpy as EventListener);
+
+    const processor = new FrontendCommandProcessor({ telemetryHook });
+
+    const result = await processor.processCommands(
+      '<widget_action><version>1</version><phase>open</phase><widget>integration-account</widget><payload>{"id":"acc_1"}</payload></widget_action>',
+    );
+
+    expect(result).toContain("[widget:open:integration-account]");
+    expect(telemetryHook).toHaveBeenCalledTimes(1);
+    expect(telemetryHook.mock.calls[0][0]).toMatchObject({
+      kind: "widget_command",
+      version: "1",
+      phase: "open",
+      widgetType: "integration-account",
+      payload: { id: "acc_1" },
+    });
+    expect(eventSpy).toHaveBeenCalledTimes(1);
+
+    window.removeEventListener("valoride:widget-action", eventSpy as EventListener);
+  });
+
+  it("keeps backward compatibility by rejecting unsupported version", async () => {
+    const processor = new FrontendCommandProcessor({});
+
+    const result = await processor.processCommands(
+      '<widget_action><version>2</version><phase>open</phase><widget>form</widget></widget_action>',
+    );
+
+    expect(result).toContain("[Widget action failed: Unsupported widget action version: 2]");
+  });
+});

--- a/webview-ui/src/utils/commandProcessor.ts
+++ b/webview-ui/src/utils/commandProcessor.ts
@@ -21,6 +21,16 @@ export interface CommandContext {
   sessionId?: string;
   addMessage?: (message: ChatMessage) => void;
   wsUtils?: WebSocketUtils | null;
+  telemetryHook?: (event: WidgetCommandTelemetryEvent) => void;
+}
+
+export interface WidgetCommandTelemetryEvent {
+  kind: "widget_command";
+  phase: "open" | "configure" | "submit";
+  widgetType: string;
+  version: string;
+  timestamp: string;
+  payload: Record<string, any>;
 }
 
 /**
@@ -56,6 +66,9 @@ export class FrontendCommandProcessor {
 
     // Process UI interaction commands
     processedContent = await this.processUICommands(processedContent);
+
+    // Process versioned widget actions
+    processedContent = await this.processWidgetCommands(processedContent);
 
     return processedContent;
   }
@@ -208,6 +221,54 @@ export class FrontendCommandProcessor {
         processedContent = processedContent.replace(
           match[0],
           `[UI action failed: ${error}]`,
+        );
+      }
+    }
+
+    return processedContent;
+  }
+
+  /**
+   * Handle versioned widget actions.
+   * Format:
+   * <widget_action>
+   *   <version>1</version>
+   *   <phase>open|configure|submit</phase>
+   *   <widget>integration-account|execmodule-config|form</widget>
+   *   <payload>{...json}</payload>
+   * </widget_action>
+   */
+  private async processWidgetCommands(content: string): Promise<string> {
+    const widgetRegex =
+      /<widget_action>\s*<version>([\s\S]*?)<\/version>\s*<phase>([\s\S]*?)<\/phase>\s*<widget>([\s\S]*?)<\/widget>(?:\s*<payload>([\s\S]*?)<\/payload>)?\s*<\/widget_action>/g;
+    let processedContent = content;
+    let match;
+
+    while ((match = widgetRegex.exec(content)) !== null) {
+      try {
+        const version = match[1].trim();
+        const phase = match[2].trim().toLowerCase();
+        const widgetType = match[3].trim();
+        const payloadRaw = match[4]?.trim();
+        const payload = payloadRaw ? JSON.parse(payloadRaw) : {};
+
+        const result = await this.executeWidgetAction({
+          version,
+          phase,
+          widgetType,
+          payload,
+        });
+
+        processedContent = processedContent.replace(
+          match[0],
+          result.success
+            ? `[widget:${phase}:${widgetType}]`
+            : `[Widget action failed: ${result.error}]`,
+        );
+      } catch (error) {
+        processedContent = processedContent.replace(
+          match[0],
+          `[Widget action failed: ${error}]`,
         );
       }
     }
@@ -369,6 +430,50 @@ export class FrontendCommandProcessor {
     } catch (error) {
       return { success: false, error: `UI action failed: ${error}` };
     }
+  }
+
+  private async executeWidgetAction({
+    version,
+    phase,
+    widgetType,
+    payload,
+  }: {
+    version: string;
+    phase: string;
+    widgetType: string;
+    payload: Record<string, any>;
+  }): Promise<CommandResult> {
+    if (version !== "1") {
+      return {
+        success: false,
+        error: `Unsupported widget action version: ${version}`,
+      };
+    }
+
+    if (phase !== "open" && phase !== "configure" && phase !== "submit") {
+      return {
+        success: false,
+        error: `Unsupported widget phase: ${phase}`,
+      };
+    }
+
+    const detail: WidgetCommandTelemetryEvent = {
+      kind: "widget_command",
+      phase,
+      widgetType,
+      version,
+      timestamp: new Date().toISOString(),
+      payload,
+    };
+
+    window.dispatchEvent(new CustomEvent("valoride:widget-action", { detail }));
+    this.context.telemetryHook?.(detail);
+
+    return {
+      success: true,
+      data: detail,
+      message: `Widget ${phase} dispatched for ${widgetType}`,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- add versioned `<widget_action>` command extension support (`version=1`)
- support deterministic `open/configure/submit` widget phases for floating widgets
- dispatch `valoride:widget-action` browser events and optional telemetry hook callbacks
- add unit tests for happy path plus backward-compatible version rejection

## Notes
- Existing command routing remains intact, new handling is additive and version-gated.
- Local test pipeline in this workspace fails before Jest due missing global type defs (`chai/mocha/node/should/vscode`).
