### PR TITLE
feat(swarm): versioned widget command protocol envelope for pop-ins (#13)

### DIFF
--- a/src/services/communication/AgentRuntimeCoordinator.js
+++ b/src/services/communication/AgentRuntimeCoordinator.js
@@ -4,6 +4,7 @@ import { MothershipService, } from "./MothershipService";
 import { Logger } from "../logging/Logger";
 import { WebviewProvider } from "../../core/webview";
 const INSTANCE_ID_KEY = "valorideSwarmInstanceId";
+const WIDGET_PROTOCOL_VERSION = "1.0";
 /**
  * Coordinates ValorIDE's swarm runtime presence when running inside VS Code.
  *
@@ -218,10 +219,51 @@ export class AgentRuntimeCoordinator {
             case "task-cancel":
                 this.handleTaskCancellation(command, payload);
                 break;
+            case "widget-open":
+            case "ui-widget-open":
+                this.handleWidgetCommand("open", command, payload);
+                break;
+            case "widget-configure":
+            case "ui-widget-configure":
+                this.handleWidgetCommand("configure", command, payload);
+                break;
+            case "widget-submit":
+            case "ui-widget-submit":
+                this.handleWidgetCommand("submit", command, payload);
+                break;
             default:
                 Logger.log(`Unhandled remote command type: ${command.type}`);
                 this.forwardRemoteCommandToWebview(command);
         }
+    }
+    handleWidgetCommand(action, command, payload) {
+        const widgetEnvelope = {
+            protocolVersion: WIDGET_PROTOCOL_VERSION,
+            action,
+            widgetType: payload?.widgetType ?? payload?.widget ?? payload?.type ?? "unknown",
+            requestId: payload?.requestId ?? command.id,
+            sourceCommandId: command.id,
+            sourceInstanceId: command.sourceInstanceId,
+            targetInstanceId: command.targetInstanceId,
+            payload,
+        };
+        this.forwardWidgetCommandToWebview(widgetEnvelope);
+        this.forwardRemoteCommandToWebview(command);
+        this.captureWidgetTelemetry(widgetEnvelope);
+    }
+    captureWidgetTelemetry(widgetCommand) {
+        if (!this.mothership || !this.instanceId) {
+            return;
+        }
+        this.mothership.sendAppTopic("telemetry", {
+            topic: "widget-command",
+            workerId: this.instanceId,
+            protocolVersion: widgetCommand.protocolVersion,
+            action: widgetCommand.action,
+            widgetType: widgetCommand.widgetType,
+            requestId: widgetCommand.requestId,
+            timestamp: Date.now(),
+        });
     }
     async handleTaskAssignment(command, payload) {
         if (!payload) {
@@ -284,6 +326,14 @@ export class AgentRuntimeCoordinator {
             instance.controller.postMessageToWebview({
                 type: "swarm:remote-command",
                 command,
+            });
+        });
+    }
+    forwardWidgetCommandToWebview(widgetCommand) {
+        WebviewProvider.getAllInstances().forEach((instance) => {
+            instance.controller.postMessageToWebview({
+                type: "swarm:widget-command",
+                widgetCommand,
             });
         });
     }

--- a/src/services/communication/AgentRuntimeCoordinator.ts
+++ b/src/services/communication/AgentRuntimeCoordinator.ts
@@ -7,6 +7,7 @@ import {
 } from "./MothershipService";
 import { Logger } from "../logging/Logger";
 import { WebviewProvider } from "../../core/webview";
+import { WidgetCommandEnvelope } from "@shared/ExtensionMessage";
 
 type GitExtension = {
   getAPI(version: number): GitAPI;
@@ -61,6 +62,7 @@ type CapabilityEnvelope = {
 };
 
 const INSTANCE_ID_KEY = "valorideSwarmInstanceId" as const;
+const WIDGET_PROTOCOL_VERSION = "1.0" as const;
 
 /**
  * Coordinates ValorIDE's swarm runtime presence when running inside VS Code.
@@ -328,10 +330,60 @@ export class AgentRuntimeCoordinator implements vscode.Disposable {
       case "task-cancel":
         this.handleTaskCancellation(command, payload);
         break;
+      case "widget-open":
+      case "ui-widget-open":
+        this.handleWidgetCommand("open", command, payload);
+        break;
+      case "widget-configure":
+      case "ui-widget-configure":
+        this.handleWidgetCommand("configure", command, payload);
+        break;
+      case "widget-submit":
+      case "ui-widget-submit":
+        this.handleWidgetCommand("submit", command, payload);
+        break;
       default:
         Logger.log(`Unhandled remote command type: ${command.type}`);
         this.forwardRemoteCommandToWebview(command);
     }
+  }
+
+  private handleWidgetCommand(
+    action: WidgetCommandEnvelope["action"],
+    command: RemoteCommand,
+    payload: any,
+  ): void {
+    const widgetEnvelope: WidgetCommandEnvelope = {
+      protocolVersion: WIDGET_PROTOCOL_VERSION,
+      action,
+      widgetType:
+        payload?.widgetType ?? payload?.widget ?? payload?.type ?? "unknown",
+      requestId: payload?.requestId ?? command.id,
+      sourceCommandId: command.id,
+      sourceInstanceId: command.sourceInstanceId,
+      targetInstanceId: command.targetInstanceId,
+      payload,
+    };
+
+    this.forwardWidgetCommandToWebview(widgetEnvelope);
+    this.forwardRemoteCommandToWebview(command);
+    this.captureWidgetTelemetry(widgetEnvelope);
+  }
+
+  private captureWidgetTelemetry(widgetCommand: WidgetCommandEnvelope): void {
+    if (!this.mothership || !this.instanceId) {
+      return;
+    }
+
+    this.mothership.sendAppTopic("telemetry", {
+      topic: "widget-command",
+      workerId: this.instanceId,
+      protocolVersion: widgetCommand.protocolVersion,
+      action: widgetCommand.action,
+      widgetType: widgetCommand.widgetType,
+      requestId: widgetCommand.requestId,
+      timestamp: Date.now(),
+    });
   }
 
   private async handleTaskAssignment(
@@ -408,6 +460,17 @@ export class AgentRuntimeCoordinator implements vscode.Disposable {
       instance.controller.postMessageToWebview({
         type: "swarm:remote-command",
         command,
+      });
+    });
+  }
+
+  private forwardWidgetCommandToWebview(
+    widgetCommand: WidgetCommandEnvelope,
+  ): void {
+    WebviewProvider.getAllInstances().forEach((instance) => {
+      instance.controller.postMessageToWebview({
+        type: "swarm:widget-command",
+        widgetCommand,
       });
     });
   }

--- a/src/shared/ExtensionMessage.tsx
+++ b/src/shared/ExtensionMessage.tsx
@@ -30,6 +30,17 @@ export interface RemoteCommand {
   targetInstanceId?: string;
 }
 
+export interface WidgetCommandEnvelope {
+  protocolVersion: "1.0";
+  action: "open" | "configure" | "submit";
+  widgetType: string;
+  requestId: string;
+  sourceCommandId?: string;
+  sourceInstanceId?: string;
+  targetInstanceId?: string;
+  payload?: Record<string, unknown>;
+}
+
 // webview will hold state
 export interface ExtensionMessage {
   type:
@@ -81,6 +92,7 @@ export interface ExtensionMessage {
   | "swarm:task-assignment"
   | "swarm:task-cancelled"
   | "swarm:remote-command"
+  | "swarm:widget-command"
   | "swarm:broadcast"
   | "valkyraiHostTestResult"
   | "swarm:private-message"
@@ -207,6 +219,7 @@ uploadOpenAPISpecResult ?: {
 filename ?: string;
 specPath ?: string;
 message ?: string;
+widgetCommand ?: WidgetCommandEnvelope;
 }
 
 export type Invoke =


### PR DESCRIPTION
## Summary
- route widget open/configure/submit remote commands through a versioned swarm:widget-command envelope
- keep backward compatibility by still forwarding raw swarm:remote-command payloads
- emit deterministic telemetry events for widget command action/type/request IDs

## Notes
- This implements the protocol extension slice for issue #13.
- npm run check-types is currently failing in this workspace due missing webview deps and pre-existing type errors unrelated to this change.

Closes #13
