### PR TITLE
feat(remote-agent): detached coding session registry slice (#10)

### DIFF
--- a/src/services/communication/RemoteCodingSessionRegistry.test.ts
+++ b/src/services/communication/RemoteCodingSessionRegistry.test.ts
@@ -1,0 +1,42 @@
+import { RemoteCodingSessionRegistry } from "./RemoteCodingSessionRegistry";
+
+describe("RemoteCodingSessionRegistry", () => {
+  it("starts and lists detached sessions", () => {
+    const registry = new RemoteCodingSessionRegistry();
+    const started = registry.start({ id: "s1", task: "Run lint", createdAt: 1000, timeoutMs: 5000 });
+
+    expect(started.status).toBe("running");
+    expect(registry.list()).toHaveLength(1);
+    expect(registry.get("s1")?.task).toBe("Run lint");
+  });
+
+  it("tracks heartbeat, logs, artifacts, and completion", () => {
+    const registry = new RemoteCodingSessionRegistry();
+    registry.start({ id: "s1", task: "Fix tests", createdAt: 1000 });
+
+    registry.heartbeat("s1", 1100);
+    registry.appendLog("s1", "step 1 complete", 1200);
+    registry.addArtifact("s1", "artifacts/run-1.log", 1300);
+    const stopped = registry.stop("s1", "completed", 1400);
+
+    expect(stopped.heartbeatAt).toBe(1100);
+    expect(stopped.logs).toEqual(["step 1 complete"]);
+    expect(stopped.artifacts).toEqual(["artifacts/run-1.log"]);
+    expect(stopped.status).toBe("completed");
+    expect(stopped.endedAt).toBe(1400);
+  });
+
+  it("supports safe cancel and timeout controls", () => {
+    const registry = new RemoteCodingSessionRegistry();
+    registry.start({ id: "cancel-me", task: "Refactor", createdAt: 0, timeoutMs: 1000 });
+    registry.start({ id: "timeout-me", task: "Docs", createdAt: 0, timeoutMs: 1000 });
+
+    const cancelled = registry.cancel("cancel-me", "user_requested", 500);
+    const timedOut = registry.expireTimedOutSessions(1501);
+
+    expect(cancelled.status).toBe("cancelled");
+    expect(cancelled.cancelReason).toBe("user_requested");
+    expect(timedOut.map(s => s.id)).toEqual(["timeout-me"]);
+    expect(registry.get("timeout-me")?.status).toBe("timed_out");
+  });
+});

--- a/src/services/communication/RemoteCodingSessionRegistry.ts
+++ b/src/services/communication/RemoteCodingSessionRegistry.ts
@@ -1,0 +1,140 @@
+export type RemoteCodingSessionStatus = "queued" | "running" | "completed" | "cancelled" | "timed_out" | "failed";
+
+export interface RemoteCodingSession {
+  id: string;
+  task: string;
+  createdAt: number;
+  updatedAt: number;
+  startedAt?: number;
+  endedAt?: number;
+  timeoutMs: number;
+  status: RemoteCodingSessionStatus;
+  heartbeatAt?: number;
+  cancelReason?: string;
+  logs: string[];
+  artifacts: string[];
+}
+
+export interface StartRemoteCodingSessionInput {
+  id: string;
+  task: string;
+  timeoutMs?: number;
+  createdAt?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+
+export class RemoteCodingSessionRegistry {
+  private sessions = new Map<string, RemoteCodingSession>();
+
+  start(input: StartRemoteCodingSessionInput): RemoteCodingSession {
+    const now = input.createdAt ?? Date.now();
+    const existing = this.sessions.get(input.id);
+    if (existing && this.isActive(existing)) {
+      throw new Error(`Remote coding session already active: ${input.id}`);
+    }
+
+    const session: RemoteCodingSession = {
+      id: input.id,
+      task: input.task,
+      timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      createdAt: now,
+      updatedAt: now,
+      startedAt: now,
+      heartbeatAt: now,
+      status: "running",
+      logs: [],
+      artifacts: []
+    };
+
+    this.sessions.set(input.id, session);
+    return { ...session, logs: [...session.logs], artifacts: [...session.artifacts] };
+  }
+
+  list(): RemoteCodingSession[] {
+    return Array.from(this.sessions.values()).map(s => ({ ...s, logs: [...s.logs], artifacts: [...s.artifacts] }));
+  }
+
+  get(sessionId: string): RemoteCodingSession | undefined {
+    const s = this.sessions.get(sessionId);
+    if (!s) {
+      return undefined;
+    }
+    return { ...s, logs: [...s.logs], artifacts: [...s.artifacts] };
+  }
+
+  heartbeat(sessionId: string, now: number = Date.now()): RemoteCodingSession {
+    const s = this.requireSession(sessionId);
+    if (!this.isActive(s)) {
+      return this.snapshot(s);
+    }
+    s.heartbeatAt = now;
+    s.updatedAt = now;
+    return this.snapshot(s);
+  }
+
+  appendLog(sessionId: string, log: string, now: number = Date.now()): RemoteCodingSession {
+    const s = this.requireSession(sessionId);
+    s.logs.push(log);
+    s.updatedAt = now;
+    return this.snapshot(s);
+  }
+
+  addArtifact(sessionId: string, artifact: string, now: number = Date.now()): RemoteCodingSession {
+    const s = this.requireSession(sessionId);
+    s.artifacts.push(artifact);
+    s.updatedAt = now;
+    return this.snapshot(s);
+  }
+
+  stop(sessionId: string, status: Extract<RemoteCodingSessionStatus, "completed" | "failed"> = "completed", now: number = Date.now()): RemoteCodingSession {
+    const s = this.requireSession(sessionId);
+    s.status = status;
+    s.endedAt = now;
+    s.updatedAt = now;
+    return this.snapshot(s);
+  }
+
+  cancel(sessionId: string, reason: string = "user_cancelled", now: number = Date.now()): RemoteCodingSession {
+    const s = this.requireSession(sessionId);
+    s.status = "cancelled";
+    s.cancelReason = reason;
+    s.endedAt = now;
+    s.updatedAt = now;
+    return this.snapshot(s);
+  }
+
+  expireTimedOutSessions(now: number = Date.now()): RemoteCodingSession[] {
+    const timedOut: RemoteCodingSession[] = [];
+    for (const s of this.sessions.values()) {
+      if (!this.isActive(s)) {
+        continue;
+      }
+      const heartbeatAt = s.heartbeatAt ?? s.startedAt ?? s.createdAt;
+      if (now - heartbeatAt <= s.timeoutMs) {
+        continue;
+      }
+      s.status = "timed_out";
+      s.endedAt = now;
+      s.updatedAt = now;
+      timedOut.push(this.snapshot(s));
+    }
+    return timedOut;
+  }
+
+  private requireSession(sessionId: string): RemoteCodingSession {
+    const s = this.sessions.get(sessionId);
+    if (!s) {
+      throw new Error(`Remote coding session not found: ${sessionId}`);
+    }
+    return s;
+  }
+
+  private isActive(session: RemoteCodingSession): boolean {
+    return session.status === "queued" || session.status === "running";
+  }
+
+  private snapshot(session: RemoteCodingSession): RemoteCodingSession {
+    return { ...session, logs: [...session.logs], artifacts: [...session.artifacts] };
+  }
+}


### PR DESCRIPTION
## Summary\n- add an in-memory RemoteCodingSessionRegistry for detached remote coding runs\n- support start/list/get, heartbeat updates, log+artifact accumulation, stop/cancel states\n- add timeout expiration helper for safe timeout controls\n- add unit tests covering lifecycle and timeout/cancel behavior\n\n## Validation\n-  *(fails locally: missing  module in current clone test runtime)*\n- yarn run v1.22.22
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command. *(fails locally: jest command not available in this clone)*