### PR TITLE
feat(remote-coding): detached session command orchestrator slice (#10)

### DIFF
--- a/src/services/communication/RemoteCodingSessionOrchestrator.test.ts
+++ b/src/services/communication/RemoteCodingSessionOrchestrator.test.ts
@@ -1,0 +1,41 @@
+import { RemoteCodingSessionRegistry } from "./RemoteCodingSessionRegistry";
+import { RemoteCodingSessionOrchestrator } from "./RemoteCodingSessionOrchestrator";
+
+describe("RemoteCodingSessionOrchestrator", () => {
+  it("supports start/list/cancel lifecycle", () => {
+    const orchestrator = new RemoteCodingSessionOrchestrator(new RemoteCodingSessionRegistry());
+
+    const started = orchestrator.handle({
+      id: "cmd-1",
+      type: "remote-coding-session-start",
+      payload: { sessionId: "s1", task: "Implement endpoint", timeoutMs: 1000 },
+    });
+    expect(started.session?.status).toBe("running");
+
+    orchestrator.handle({
+      id: "cmd-2",
+      type: "remote-coding-session-heartbeat",
+      payload: { sessionId: "s1" },
+    });
+
+    orchestrator.handle({
+      id: "cmd-3",
+      type: "remote-coding-session-log",
+      payload: { sessionId: "s1", log: "step1" },
+    });
+
+    const listed = orchestrator.handle({
+      id: "cmd-4",
+      type: "remote-coding-session-list",
+    });
+    expect(listed.sessions?.length).toBe(1);
+    expect(listed.sessions?.[0].logs).toEqual(["step1"]);
+
+    const cancelled = orchestrator.handle({
+      id: "cmd-5",
+      type: "remote-coding-session-cancel",
+      payload: { sessionId: "s1", reason: "user_requested" },
+    });
+    expect(cancelled.session?.status).toBe("cancelled");
+  });
+});

--- a/src/services/communication/RemoteCodingSessionOrchestrator.ts
+++ b/src/services/communication/RemoteCodingSessionOrchestrator.ts
@@ -1,0 +1,81 @@
+import {
+  RemoteCodingSession,
+  RemoteCodingSessionRegistry,
+} from "./RemoteCodingSessionRegistry";
+
+export type RemoteCodingCommandType =
+  | "remote-coding-session-start"
+  | "remote-coding-session-heartbeat"
+  | "remote-coding-session-log"
+  | "remote-coding-session-artifact"
+  | "remote-coding-session-stop"
+  | "remote-coding-session-cancel"
+  | "remote-coding-session-list";
+
+export interface RemoteCodingCommand {
+  id: string;
+  type: RemoteCodingCommandType;
+  payload?: Record<string, any>;
+}
+
+export interface RemoteCodingCommandResult {
+  event: "session-updated" | "session-list";
+  session?: RemoteCodingSession;
+  sessions?: RemoteCodingSession[];
+}
+
+export class RemoteCodingSessionOrchestrator {
+  constructor(private readonly registry: RemoteCodingSessionRegistry) {}
+
+  handle(command: RemoteCodingCommand): RemoteCodingCommandResult {
+    const payload = command.payload ?? {};
+    const sessionId = payload.sessionId ?? payload.id;
+
+    switch (command.type) {
+      case "remote-coding-session-start":
+        return {
+          event: "session-updated",
+          session: this.registry.start({
+            id: String(sessionId),
+            task: String(payload.task ?? ""),
+            timeoutMs: payload.timeoutMs,
+          }),
+        };
+      case "remote-coding-session-heartbeat":
+        return {
+          event: "session-updated",
+          session: this.registry.heartbeat(String(sessionId)),
+        };
+      case "remote-coding-session-log":
+        return {
+          event: "session-updated",
+          session: this.registry.appendLog(String(sessionId), String(payload.log ?? "")),
+        };
+      case "remote-coding-session-artifact":
+        return {
+          event: "session-updated",
+          session: this.registry.addArtifact(String(sessionId), String(payload.artifact ?? "")),
+        };
+      case "remote-coding-session-stop":
+        return {
+          event: "session-updated",
+          session: this.registry.stop(String(sessionId), payload.status === "failed" ? "failed" : "completed"),
+        };
+      case "remote-coding-session-cancel":
+        return {
+          event: "session-updated",
+          session: this.registry.cancel(String(sessionId), String(payload.reason ?? "user_cancelled")),
+        };
+      case "remote-coding-session-list":
+        return {
+          event: "session-list",
+          sessions: this.registry.list(),
+        };
+      default:
+        return {
+          event: "session-list",
+          sessions: this.registry.list(),
+        };
+    }
+  }
+}


### PR DESCRIPTION
## Summary\n- add  to normalize start/heartbeat/log/artifact/stop/cancel/list command handling for detached coding sessions\n- wire orchestration around existing  so session lifecycle state remains auditable and deterministic\n- add focused unit coverage for start/list/cancel flow\n\n## Validation\n- \n\n@codex review