### PR TITLE
[codex] remove React Query from generated app dependencies

### DIFF
--- a/src/services/thorapiGeneratorService.js
+++ b/src/services/thorapiGeneratorService.js
@@ -221,7 +221,6 @@ export class ThorAPIGeneratorService {
                 dependencies: {
                     react: "^18.0.0",
                     "@reduxjs/toolkit": "^1.9.0",
-                    "@tanstack/react-query": "^4.0.0",
                 },
             };
             fs.writeFileSync(path.join(appDir, "package.json"), JSON.stringify(packageJson, null, 2));

--- a/src/services/thorapiGeneratorService.ts
+++ b/src/services/thorapiGeneratorService.ts
@@ -345,7 +345,6 @@ export class ThorAPIGeneratorService {
         dependencies: {
           react: "^18.0.0",
           "@reduxjs/toolkit": "^1.9.0",
-          "@tanstack/react-query": "^4.0.0",
         },
       };
       fs.writeFileSync(


### PR DESCRIPTION
## Summary
- Removes `@tanstack/react-query` from the ThorAPI generated app package template.
- Keeps generated apps on React plus RTK Query instead of adding a second server-state library.
- Uses a clean branch from `origin/rc-5` so unrelated local ValorIDE edits are not included.

## Validation
- Searched the PR worktrees for `@tanstack/react-query` and `QueryClientProvider`; no matches remained.
- `git diff --check` passed.
- `node --check src/services/thorapiGeneratorService.js` passed.
- `npm run check-types` was attempted; it fails in unrelated files because `webview-ui/src/components/content-data/ContentDataFlipBoard.tsx` and `ContentFlipCard.tsx` import `three`, but `three` is not installed/declared in this branch.