### PR TITLE
feat: orchestrate remote coding timeout expiry command

### DIFF
--- a/src/services/communication/RemoteCodingSessionOrchestrator.test.ts
+++ b/src/services/communication/RemoteCodingSessionOrchestrator.test.ts
@@ -38,4 +38,20 @@ describe("RemoteCodingSessionOrchestrator", () => {
     });
     expect(cancelled.session?.status).toBe("cancelled");
   });
+
+  it("expires timed-out sessions via command", () => {
+    const registry = new RemoteCodingSessionRegistry();
+    const orchestrator = new RemoteCodingSessionOrchestrator(registry);
+
+    registry.start({ id: "s2", task: "Long run", timeoutMs: 1, createdAt: 100 });
+
+    const expired = orchestrator.handle({
+      id: "cmd-6",
+      type: "remote-coding-session-expire-timeouts",
+    });
+
+    expect(expired.sessions?.length).toBe(1);
+    expect(expired.sessions?.[0].id).toBe("s2");
+    expect(expired.sessions?.[0].status).toBe("timed_out");
+  });
 });

--- a/src/services/communication/RemoteCodingSessionOrchestrator.ts
+++ b/src/services/communication/RemoteCodingSessionOrchestrator.ts
@@ -10,6 +10,7 @@ export type RemoteCodingCommandType =
   | "remote-coding-session-artifact"
   | "remote-coding-session-stop"
   | "remote-coding-session-cancel"
+  | "remote-coding-session-expire-timeouts"
   | "remote-coding-session-list";
 
 export interface RemoteCodingCommand {
@@ -65,6 +66,11 @@ export class RemoteCodingSessionOrchestrator {
         return {
           event: "session-updated",
           session: this.registry.cancel(String(sessionId), String(payload.reason ?? "user_cancelled")),
+        };
+      case "remote-coding-session-expire-timeouts":
+        return {
+          event: "session-list",
+          sessions: this.registry.expireTimedOutSessions(),
         };
       case "remote-coding-session-list":
         return {


### PR DESCRIPTION
Implements a shippable slice of #10 by wiring timeout enforcement into the remote coding command bus.\n\n## What changed\n- Added  command handling in \n- Returns timed-out sessions from registry sweep for status-stream consumers\n- Added orchestrator test coverage for timeout expiry path\n\n## Validation\n- \n\n@codex review