### PR TITLE
feat(remote-coding): add task template catalog + saved presets

### DIFF
--- a/src/services/communication/RemoteCodingSessionOrchestrator.test.ts
+++ b/src/services/communication/RemoteCodingSessionOrchestrator.test.ts
@@ -54,4 +54,40 @@ describe("RemoteCodingSessionOrchestrator", () => {
     expect(expired.sessions?.[0].id).toBe("s2");
     expect(expired.sessions?.[0].status).toBe("timed_out");
   });
+
+  it("supports template listing and preset-driven starts", () => {
+    const orchestrator = new RemoteCodingSessionOrchestrator(new RemoteCodingSessionRegistry());
+
+    const templates = orchestrator.handle({
+      id: "cmd-7",
+      type: "remote-coding-template-list",
+    });
+    expect(templates.templates?.length).toBeGreaterThan(0);
+
+    const saved = orchestrator.handle({
+      id: "cmd-8",
+      type: "remote-coding-preset-save",
+      payload: {
+        id: "org-docs",
+        name: "Org docs preset",
+        scope: "org",
+        ownerId: "valkyrlabs",
+        templateId: "docs",
+        params: {
+          area: "remote sessions",
+        },
+      },
+    });
+    expect(saved.preset?.id).toBe("org-docs");
+
+    const startedFromPreset = orchestrator.handle({
+      id: "cmd-9",
+      type: "remote-coding-session-start",
+      payload: {
+        sessionId: "s9",
+        presetId: "org-docs",
+      },
+    });
+    expect(startedFromPreset.session?.task).toContain("remote sessions");
+  });
 });

--- a/src/services/communication/RemoteCodingSessionOrchestrator.ts
+++ b/src/services/communication/RemoteCodingSessionOrchestrator.ts
@@ -2,6 +2,13 @@ import {
   RemoteCodingSession,
   RemoteCodingSessionRegistry,
 } from "./RemoteCodingSessionRegistry";
+import {
+  RemoteCodingTaskPresetCatalog,
+  RemotePresetScope,
+  RemoteTaskTemplate,
+  RemoteTaskTemplateId,
+  SavedRemoteTaskPreset,
+} from "./RemoteCodingTaskPresetCatalog";
 
 export type RemoteCodingCommandType =
   | "remote-coding-session-start"
@@ -11,7 +18,10 @@ export type RemoteCodingCommandType =
   | "remote-coding-session-stop"
   | "remote-coding-session-cancel"
   | "remote-coding-session-expire-timeouts"
-  | "remote-coding-session-list";
+  | "remote-coding-session-list"
+  | "remote-coding-template-list"
+  | "remote-coding-preset-save"
+  | "remote-coding-preset-list";
 
 export interface RemoteCodingCommand {
   id: string;
@@ -20,28 +30,41 @@ export interface RemoteCodingCommand {
 }
 
 export interface RemoteCodingCommandResult {
-  event: "session-updated" | "session-list";
+  event: "session-updated" | "session-list" | "template-list" | "preset-list" | "preset-updated";
   session?: RemoteCodingSession;
   sessions?: RemoteCodingSession[];
+  templates?: RemoteTaskTemplate[];
+  preset?: SavedRemoteTaskPreset;
+  presets?: SavedRemoteTaskPreset[];
 }
 
 export class RemoteCodingSessionOrchestrator {
-  constructor(private readonly registry: RemoteCodingSessionRegistry) {}
+  constructor(
+    private readonly registry: RemoteCodingSessionRegistry,
+    private readonly presetCatalog: RemoteCodingTaskPresetCatalog = new RemoteCodingTaskPresetCatalog(),
+  ) {}
 
   handle(command: RemoteCodingCommand): RemoteCodingCommandResult {
     const payload = command.payload ?? {};
     const sessionId = payload.sessionId ?? payload.id;
 
     switch (command.type) {
-      case "remote-coding-session-start":
+      case "remote-coding-session-start": {
+        const task = payload.presetId
+          ? this.presetCatalog.renderTaskFromPreset(String(payload.presetId))
+          : payload.templateId
+            ? this.presetCatalog.renderTask(String(payload.templateId), payload.params ?? {})
+            : String(payload.task ?? "");
+
         return {
           event: "session-updated",
           session: this.registry.start({
             id: String(sessionId),
-            task: String(payload.task ?? ""),
+            task,
             timeoutMs: payload.timeoutMs,
           }),
         };
+      }
       case "remote-coding-session-heartbeat":
         return {
           event: "session-updated",
@@ -76,6 +99,31 @@ export class RemoteCodingSessionOrchestrator {
         return {
           event: "session-list",
           sessions: this.registry.list(),
+        };
+      case "remote-coding-template-list":
+        return {
+          event: "template-list",
+          templates: this.presetCatalog.listTemplates(),
+        };
+      case "remote-coding-preset-save":
+        return {
+          event: "preset-updated",
+          preset: this.presetCatalog.savePreset({
+            id: String(payload.id ?? sessionId ?? command.id),
+            name: String(payload.name ?? ""),
+            scope: (payload.scope === "team" ? "team" : "org") as RemotePresetScope,
+            ownerId: String(payload.ownerId ?? "default"),
+            templateId: String(payload.templateId ?? "bugfix") as RemoteTaskTemplateId,
+            params: (payload.params ?? {}) as Record<string, string>,
+          }),
+        };
+      case "remote-coding-preset-list":
+        return {
+          event: "preset-list",
+          presets: this.presetCatalog.listSavedPresets(
+            payload.scope === "team" || payload.scope === "org" ? payload.scope : undefined,
+            payload.ownerId ? String(payload.ownerId) : undefined,
+          ),
         };
       default:
         return {

--- a/src/services/communication/RemoteCodingTaskPresetCatalog.test.ts
+++ b/src/services/communication/RemoteCodingTaskPresetCatalog.test.ts
@@ -1,0 +1,38 @@
+import { RemoteCodingTaskPresetCatalog } from "./RemoteCodingTaskPresetCatalog";
+
+describe("RemoteCodingTaskPresetCatalog", () => {
+  it("exposes core templates", () => {
+    const catalog = new RemoteCodingTaskPresetCatalog();
+    const ids = catalog.listTemplates().map((template) => template.id);
+    expect(ids).toEqual(["bugfix", "refactor", "docs", "data-patch"]);
+  });
+
+  it("renders template tasks and supports saved presets", () => {
+    const catalog = new RemoteCodingTaskPresetCatalog();
+
+    const rendered = catalog.renderTask("bugfix", {
+      area: "oauth callback",
+      repro: "click login and observe 500",
+      riskSurface: "billing endpoints",
+    });
+    expect(rendered).toContain("oauth callback");
+
+    catalog.savePreset({
+      id: "team-bugfix",
+      name: "Team bugfix preset",
+      scope: "team",
+      ownerId: "core-platform",
+      templateId: "bugfix",
+      params: {
+        area: "account sync",
+        repro: "sync endpoint times out",
+      },
+      now: 100,
+    });
+
+    const listed = catalog.listSavedPresets("team", "core-platform");
+    expect(listed).toHaveLength(1);
+    expect(catalog.renderTaskFromPreset("team-bugfix")).toContain("account sync");
+    expect(catalog.renderTaskFromPreset("team-bugfix")).toContain("release notes");
+  });
+});

--- a/src/services/communication/RemoteCodingTaskPresetCatalog.ts
+++ b/src/services/communication/RemoteCodingTaskPresetCatalog.ts
@@ -1,0 +1,168 @@
+export type RemoteTaskTemplateId = "bugfix" | "refactor" | "docs" | "data-patch";
+
+export interface RemoteTaskTemplateParam {
+  key: string;
+  label: string;
+  required?: boolean;
+  defaultValue?: string;
+}
+
+export interface RemoteTaskTemplate {
+  id: RemoteTaskTemplateId;
+  title: string;
+  summary: string;
+  taskTemplate: string;
+  params: RemoteTaskTemplateParam[];
+}
+
+export type RemotePresetScope = "org" | "team";
+
+export interface SavedRemoteTaskPreset {
+  id: string;
+  name: string;
+  scope: RemotePresetScope;
+  ownerId: string;
+  templateId: RemoteTaskTemplateId;
+  params: Record<string, string>;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SaveRemoteTaskPresetInput {
+  id: string;
+  name: string;
+  scope: RemotePresetScope;
+  ownerId: string;
+  templateId: RemoteTaskTemplateId;
+  params?: Record<string, string>;
+  now?: number;
+}
+
+const DEFAULT_TEMPLATES: RemoteTaskTemplate[] = [
+  {
+    id: "bugfix",
+    title: "Bugfix",
+    summary: "Reproduce, fix, and test a defect",
+    taskTemplate:
+      "Fix bug in {{area}}. Repro: {{repro}}. Add regression tests and summarize risk in {{riskSurface}}.",
+    params: [
+      { key: "area", label: "Affected area", required: true },
+      { key: "repro", label: "Reproduction steps", required: true },
+      { key: "riskSurface", label: "Risk surface", defaultValue: "release notes" },
+    ],
+  },
+  {
+    id: "refactor",
+    title: "Refactor",
+    summary: "Improve code structure without behavior changes",
+    taskTemplate:
+      "Refactor {{area}} to improve {{goal}} while keeping behavior identical. Add/adjust tests for changed seams.",
+    params: [
+      { key: "area", label: "Scope", required: true },
+      { key: "goal", label: "Refactor goal", required: true },
+    ],
+  },
+  {
+    id: "docs",
+    title: "Docs",
+    summary: "Produce concise documentation updates",
+    taskTemplate:
+      "Update documentation for {{area}} focused on {{audience}}. Include quickstart and known caveats.",
+    params: [
+      { key: "area", label: "Document area", required: true },
+      { key: "audience", label: "Audience", defaultValue: "operators" },
+    ],
+  },
+  {
+    id: "data-patch",
+    title: "Data patch",
+    summary: "Prepare and validate a data backfill/repair",
+    taskTemplate:
+      "Create data patch for {{dataset}} with change {{change}}. Add dry-run verification and rollback plan.",
+    params: [
+      { key: "dataset", label: "Dataset", required: true },
+      { key: "change", label: "Patch change", required: true },
+    ],
+  },
+];
+
+export class RemoteCodingTaskPresetCatalog {
+  private readonly templates = new Map<RemoteTaskTemplateId, RemoteTaskTemplate>();
+
+  private readonly savedPresets = new Map<string, SavedRemoteTaskPreset>();
+
+  constructor(templates: RemoteTaskTemplate[] = DEFAULT_TEMPLATES) {
+    for (const template of templates) {
+      this.templates.set(template.id, template);
+    }
+  }
+
+  listTemplates(): RemoteTaskTemplate[] {
+    return Array.from(this.templates.values()).map((template) => ({ ...template, params: [...template.params] }));
+  }
+
+  savePreset(input: SaveRemoteTaskPresetInput): SavedRemoteTaskPreset {
+    const template = this.requireTemplate(input.templateId);
+    const now = input.now ?? Date.now();
+    const params = this.normalizeParams(template, input.params ?? {});
+
+    const existing = this.savedPresets.get(input.id);
+    const createdAt = existing?.createdAt ?? now;
+
+    const preset: SavedRemoteTaskPreset = {
+      id: input.id,
+      name: input.name,
+      scope: input.scope,
+      ownerId: input.ownerId,
+      templateId: input.templateId,
+      params,
+      createdAt,
+      updatedAt: now,
+    };
+
+    this.savedPresets.set(input.id, preset);
+    return { ...preset, params: { ...preset.params } };
+  }
+
+  listSavedPresets(scope?: RemotePresetScope, ownerId?: string): SavedRemoteTaskPreset[] {
+    return Array.from(this.savedPresets.values())
+      .filter((preset) => (scope ? preset.scope === scope : true))
+      .filter((preset) => (ownerId ? preset.ownerId === ownerId : true))
+      .map((preset) => ({ ...preset, params: { ...preset.params } }));
+  }
+
+  renderTask(templateId: RemoteTaskTemplateId, params: Record<string, string>): string {
+    const template = this.requireTemplate(templateId);
+    const normalizedParams = this.normalizeParams(template, params);
+    return template.taskTemplate.replace(/{{\s*([a-zA-Z0-9_-]+)\s*}}/g, (_match, key: string) => normalizedParams[key] ?? "").trim();
+  }
+
+  renderTaskFromPreset(presetId: string): string {
+    const preset = this.savedPresets.get(presetId);
+    if (!preset) {
+      throw new Error(`Unknown remote preset: ${presetId}`);
+    }
+    return this.renderTask(preset.templateId, preset.params);
+  }
+
+  private requireTemplate(templateId: RemoteTaskTemplateId): RemoteTaskTemplate {
+    const template = this.templates.get(templateId);
+    if (!template) {
+      throw new Error(`Unknown remote task template: ${templateId}`);
+    }
+    return template;
+  }
+
+  private normalizeParams(template: RemoteTaskTemplate, params: Record<string, string>): Record<string, string> {
+    const normalized: Record<string, string> = {};
+    for (const definition of template.params) {
+      const provided = params[definition.key];
+      const value = provided?.trim() || definition.defaultValue || "";
+      if (definition.required && value.length === 0) {
+        throw new Error(`Missing required template param: ${definition.key}`);
+      }
+      normalized[definition.key] = value;
+    }
+    return normalized;
+  }
+}


### PR DESCRIPTION
## Summary
- add a remote coding task template catalog with built-in bugfix/refactor/docs/data-patch templates
- add preset persistence for org/team scope with parameter validation and task rendering
- extend remote coding session orchestrator commands to list templates, save/list presets, and start sessions from a template or saved preset
- add tests for catalog behavior and preset-driven orchestrator startup

## Validation
- [blocked] 
  - fails in this clean clone because local dependency resolution is incomplete ( from jest transform); installing ad-hoc deps also hit peer-resolution conflicts without a full workspace install.
