### PR TITLE
feat: remote task template catalog + saved org/team presets

### DIFF
--- a/src/services/communication/RemoteTaskPresetRegistry.test.ts
+++ b/src/services/communication/RemoteTaskPresetRegistry.test.ts
@@ -1,0 +1,58 @@
+import { RemoteTaskPresetRegistry } from "./RemoteTaskPresetRegistry";
+
+describe("RemoteTaskPresetRegistry", () => {
+  it("saves org and team presets", () => {
+    const registry = new RemoteTaskPresetRegistry();
+
+    registry.save({
+      id: "org-bugfix",
+      name: "Org Bugfix",
+      scope: "org",
+      scopeId: "valkyrlabs",
+      templateId: "bugfix",
+      payload: { issue: "#14", target: "launcher" },
+      now: 1000,
+    });
+
+    registry.save({
+      id: "team-docs",
+      name: "Team Docs",
+      scope: "team",
+      scopeId: "platform",
+      templateId: "docs",
+      payload: { topic: "deployment checklist" },
+      now: 1200,
+    });
+
+    expect(registry.list({ scope: "org", scopeId: "valkyrlabs" })).toHaveLength(1);
+    expect(registry.list({ scope: "team", scopeId: "platform" })).toHaveLength(1);
+  });
+
+  it("updates an existing preset deterministically", () => {
+    const registry = new RemoteTaskPresetRegistry();
+
+    registry.save({
+      id: "org-bugfix",
+      name: "Org Bugfix",
+      scope: "org",
+      scopeId: "valkyrlabs",
+      templateId: "bugfix",
+      payload: { issue: "#14", target: "launcher" },
+      now: 1000,
+    });
+
+    const updated = registry.save({
+      id: "org-bugfix",
+      name: "Org Bugfix v2",
+      scope: "org",
+      scopeId: "valkyrlabs",
+      templateId: "bugfix",
+      payload: { issue: "#14", target: "session panel" },
+      now: 2000,
+    });
+
+    expect(updated.createdAt).toBe(1000);
+    expect(updated.updatedAt).toBe(2000);
+    expect(updated.payload.target).toBe("session panel");
+  });
+});

--- a/src/services/communication/RemoteTaskPresetRegistry.ts
+++ b/src/services/communication/RemoteTaskPresetRegistry.ts
@@ -1,0 +1,68 @@
+import { RemoteTaskTemplateId, RemoteTaskTemplatePayload } from "./RemoteTaskTemplates";
+
+export interface RemoteTaskPreset {
+  id: string;
+  name: string;
+  scope: "org" | "team";
+  scopeId: string;
+  templateId: RemoteTaskTemplateId;
+  payload: RemoteTaskTemplatePayload;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SaveRemoteTaskPresetInput {
+  id: string;
+  name: string;
+  scope: "org" | "team";
+  scopeId: string;
+  templateId: RemoteTaskTemplateId;
+  payload: RemoteTaskTemplatePayload;
+  now?: number;
+}
+
+export class RemoteTaskPresetRegistry {
+  private presets = new Map<string, RemoteTaskPreset>();
+
+  save(input: SaveRemoteTaskPresetInput): RemoteTaskPreset {
+    const now = input.now ?? Date.now();
+    const existing = this.presets.get(input.id);
+
+    const next: RemoteTaskPreset = {
+      id: input.id,
+      name: input.name,
+      scope: input.scope,
+      scopeId: input.scopeId,
+      templateId: input.templateId,
+      payload: { ...input.payload },
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+
+    this.presets.set(next.id, next);
+    return this.snapshot(next);
+  }
+
+  list(scope?: { scope: "org" | "team"; scopeId: string }): RemoteTaskPreset[] {
+    return Array.from(this.presets.values())
+      .filter((preset) => {
+        if (!scope) {
+          return true;
+        }
+        return preset.scope === scope.scope && preset.scopeId === scope.scopeId;
+      })
+      .map((preset) => this.snapshot(preset));
+  }
+
+  get(id: string): RemoteTaskPreset | undefined {
+    const preset = this.presets.get(id);
+    if (!preset) {
+      return undefined;
+    }
+    return this.snapshot(preset);
+  }
+
+  private snapshot(preset: RemoteTaskPreset): RemoteTaskPreset {
+    return { ...preset, payload: { ...preset.payload } };
+  }
+}

--- a/src/services/communication/RemoteTaskTemplates.test.ts
+++ b/src/services/communication/RemoteTaskTemplates.test.ts
@@ -1,0 +1,43 @@
+import { RemoteTaskTemplateCatalog } from "./RemoteTaskTemplates";
+
+describe("RemoteTaskTemplateCatalog", () => {
+  it("exposes one-click template catalog", () => {
+    const catalog = new RemoteTaskTemplateCatalog();
+    const templates = catalog.list();
+
+    expect(templates.map((template) => template.id)).toEqual([
+      "bugfix",
+      "refactor",
+      "docs",
+      "data-patch",
+    ]);
+  });
+
+  it("renders parameterized prompts and defaults", () => {
+    const catalog = new RemoteTaskTemplateCatalog();
+
+    const prompt = catalog.renderPrompt("docs", {
+      topic: "runbook alerts",
+    });
+
+    expect(prompt).toContain("runbook alerts");
+    expect(prompt).toContain("engineers");
+  });
+
+  it("builds execution summary with reusable links", () => {
+    const catalog = new RemoteTaskTemplateCatalog();
+
+    const summary = catalog.buildExecutionSummary(
+      "bugfix",
+      {
+        issue: "#14",
+        target: "remote task launcher",
+      },
+      ["https://example.com/runs/1", "https://example.com/pr/22"]
+    );
+
+    expect(summary.title).toBe("Bugfix");
+    expect(summary.prompt).toContain("#14");
+    expect(summary.outputLinks).toHaveLength(2);
+  });
+});

--- a/src/services/communication/RemoteTaskTemplates.ts
+++ b/src/services/communication/RemoteTaskTemplates.ts
@@ -1,0 +1,115 @@
+export type RemoteTaskTemplateId = "bugfix" | "refactor" | "docs" | "data-patch";
+
+export interface RemoteTaskTemplateField {
+  key: string;
+  label: string;
+  required?: boolean;
+  defaultValue?: string;
+}
+
+export interface RemoteTaskTemplate {
+  id: RemoteTaskTemplateId;
+  name: string;
+  summary: string;
+  fields: RemoteTaskTemplateField[];
+  prompt: string;
+}
+
+export interface RemoteTaskTemplatePayload {
+  [key: string]: string | undefined;
+}
+
+export interface RemoteTaskExecutionSummary {
+  templateId: RemoteTaskTemplateId;
+  title: string;
+  prompt: string;
+  outputLinks: string[];
+}
+
+const CATALOG: RemoteTaskTemplate[] = [
+  {
+    id: "bugfix",
+    name: "Bugfix",
+    summary: "Investigate a failing behavior and implement a tested fix.",
+    fields: [
+      { key: "issue", label: "Issue", required: true },
+      { key: "target", label: "Target module", required: true },
+      { key: "constraints", label: "Constraints", defaultValue: "Keep scope minimal." }
+    ],
+    prompt: "Fix issue {{issue}} in {{target}}. Constraints: {{constraints}}"
+  },
+  {
+    id: "refactor",
+    name: "Refactor",
+    summary: "Improve internal design while preserving behavior.",
+    fields: [
+      { key: "target", label: "Target module", required: true },
+      { key: "goal", label: "Refactor goal", required: true }
+    ],
+    prompt: "Refactor {{target}} to improve {{goal}} without behavior changes."
+  },
+  {
+    id: "docs",
+    name: "Docs",
+    summary: "Improve or add documentation with examples.",
+    fields: [
+      { key: "topic", label: "Topic", required: true },
+      { key: "audience", label: "Audience", defaultValue: "engineers" }
+    ],
+    prompt: "Write documentation for {{topic}} for {{audience}}, including practical examples."
+  },
+  {
+    id: "data-patch",
+    name: "Data Patch",
+    summary: "Apply a deterministic data correction with rollback notes.",
+    fields: [
+      { key: "dataset", label: "Dataset", required: true },
+      { key: "change", label: "Requested change", required: true }
+    ],
+    prompt: "Create a safe data patch for {{dataset}} that performs: {{change}}. Include rollback steps."
+  }
+];
+
+export class RemoteTaskTemplateCatalog {
+  list(): RemoteTaskTemplate[] {
+    return CATALOG.map((template) => ({ ...template, fields: [...template.fields] }));
+  }
+
+  get(templateId: RemoteTaskTemplateId): RemoteTaskTemplate {
+    const template = CATALOG.find((entry) => entry.id === templateId);
+    if (!template) {
+      throw new Error(`Unknown template: ${templateId}`);
+    }
+    return { ...template, fields: [...template.fields] };
+  }
+
+  renderPrompt(templateId: RemoteTaskTemplateId, payload: RemoteTaskTemplatePayload): string {
+    const template = this.get(templateId);
+
+    for (const field of template.fields) {
+      const value = payload[field.key] ?? field.defaultValue;
+      if (field.required && !value?.trim()) {
+        throw new Error(`Missing required field: ${field.key}`);
+      }
+    }
+
+    return template.prompt.replace(/{{\s*([a-zA-Z0-9_-]+)\s*}}/g, (_match, key: string) => {
+      const value = payload[key] ?? template.fields.find((field) => field.key === key)?.defaultValue;
+      return value?.trim() ?? "";
+    }).trim();
+  }
+
+  buildExecutionSummary(
+    templateId: RemoteTaskTemplateId,
+    payload: RemoteTaskTemplatePayload,
+    outputLinks: string[]
+  ): RemoteTaskExecutionSummary {
+    const template = this.get(templateId);
+    return {
+      templateId,
+      title: template.name,
+      prompt: this.renderPrompt(templateId, payload),
+      outputLinks,
+    };
+  }
+}


### PR DESCRIPTION
## Summary\n- add a built-in remote task template catalog (bugfix, refactor, docs, data patch)\n- add parameterized prompt rendering + execution summary link output helper\n- add in-memory org/team preset registry for reusable launches\n\n## Testing\n- Added unit tests for catalog rendering and summary generation\n- Added unit tests for org/team preset save/update semantics\n- Repo baseline compile-tests currently fails due existing tsconfig/rootDir issues unrelated to this diff