### PR TITLE
feat(remote): add detached coding session command bridge (#10)

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -88,6 +88,8 @@ import {
   deleteRuleFile,
   refreshValorIDERulesToggles,
 } from "../context/instructions/user-instructions/valoride-rules";
+import { RemoteCodingSessionOrchestrator } from "@services/communication/RemoteCodingSessionOrchestrator";
+import { RemoteCodingSessionRegistry } from "@services/communication/RemoteCodingSessionRegistry";
 
 /*
 https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
@@ -104,6 +106,7 @@ export class Controller {
   workspaceTracker: WorkspaceTracker;
   mcpHub: McpHub;
   accountService: ValorIDEAccountService;
+  private remoteCodingSessionOrchestrator = new RemoteCodingSessionOrchestrator(new RemoteCodingSessionRegistry());
   private latestAnnouncementId = "april-18-2025_21:15::00"; // update to some unique identifier when we add a new announcement
   private webviewIndexSourceMapPromise: Promise<any | null> | null = null;
 
@@ -1412,6 +1415,18 @@ export class Controller {
         } else {
           vscode.window.showInformationMessage("API throttle cleared");
         }
+        break;
+      }
+      case "remoteCodingSessionCommand": {
+        if (!message.remoteCodingCommand) {
+          break;
+        }
+
+        const result = this.remoteCodingSessionOrchestrator.handle(message.remoteCodingCommand);
+        await this.postMessageToWebview({
+          type: "remoteCodingSessionEvent",
+          remoteCodingSessionEvent: result,
+        });
         break;
       }
       case "clearAllTaskHistory": {

--- a/src/shared/ExtensionMessage.tsx
+++ b/src/shared/ExtensionMessage.tsx
@@ -96,6 +96,7 @@ export interface ExtensionMessage {
   | "swarm:broadcast"
   | "valkyraiHostTestResult"
   | "swarm:private-message"
+  | "remoteCodingSessionEvent"
   | "taskCompletionFilePreview"
   | "webviewError"
   | "serverConsoleNewMessage";
@@ -118,6 +119,11 @@ export interface ExtensionMessage {
   | "serverConsoleButtonClicked";
 
 invoke ?: Invoke;
+  remoteCodingSessionEvent?: {
+    event: "session-updated" | "session-list";
+    session?: Record<string, any>;
+    sessions?: Record<string, any>[];
+  };
 state ?: ExtensionState;
 images ?: string[];
 ollamaModels ?: string[];

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -104,6 +104,7 @@ export interface WebviewMessage {
   | "startServer"
   | "uploadOpenAPISpec"
   | "uploadOpenAPISpecResult"
+  | "remoteCodingSessionCommand"
   | "openFile";
 
   // | "relaunchChromeDebugMode"
@@ -183,6 +184,19 @@ export interface WebviewMessage {
   llmDetails?: LlmDetailsSummary;
   taskIntent?: string;
   valkyraiHost?: string;
+  remoteCodingCommand?: {
+    id: string;
+    type:
+      | "remote-coding-session-start"
+      | "remote-coding-session-heartbeat"
+      | "remote-coding-session-log"
+      | "remote-coding-session-artifact"
+      | "remote-coding-session-stop"
+      | "remote-coding-session-cancel"
+      | "remote-coding-session-expire-timeouts"
+      | "remote-coding-session-list";
+    payload?: Record<string, any>;
+  };
 }
 
 export type ValorIDEAskResponse =


### PR DESCRIPTION
## Summary
- add a webview command payload for remote coding session orchestration commands
- wire controller handling for start/list/heartbeat/log/artifact/stop/cancel/timeout-expire commands
- emit a structured remoteCodingSessionEvent message back to UI for session updates and list responses

## Validation
- attempted: npm test -- RemoteCodingSessionRegistry.test.ts RemoteCodingSessionOrchestrator.test.ts
- blocked locally by missing type definition dependencies in this clone during pretest compile

Closes #10