### PR TITLE
fix(credit-intent): wire resume context into AccountView (#2846)

### DIFF
--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -392,9 +392,6 @@ const AppContent = () => {
               onConsumeInitialActiveTab={() => setAccountInitialActiveTab(undefined)}
               creditIntent={creditIntent}
               onClearCreditIntent={() => setCreditIntent(undefined)}
-              onConsumeInitialActiveTab={() =>
-                setAccountInitialActiveTab(undefined)
-              }
             />
           )}
           {showGeneratedFiles && <GeneratedFilesView />}

--- a/webview-ui/src/components/account/AccountView.tsx
+++ b/webview-ui/src/components/account/AccountView.tsx
@@ -77,6 +77,8 @@ const AccountView = ({
   onClearServerConsoleNeedsAttention,
   initialActiveTab,
   onConsumeInitialActiveTab,
+  creditIntent,
+  onClearCreditIntent,
 }: AccountViewProps) => {
   const { userInfo, authenticatedUser, isLoggedIn, jwtToken } =
     useExtensionState();


### PR DESCRIPTION
## Summary
- pass `creditIntent` and `onClearCreditIntent` through `AccountView` props so insufficient-credit context is rendered and clearable
- remove duplicate `onConsumeInitialActiveTab` prop wiring in `App.tsx` that could shadow callback behavior
- keep the account routing flow consistent for credit-intent-triggered upgrade moments

## Validation
- targeted vitest run attempted for account and apiErrors slices, but this checkout lacks required runtime deps (`@reduxjs/toolkit`, `react-bootstrap`) so tests could not execute locally

Closes ValkyrLabs/ValkyrAI#2846
