### PR TITLE
Persist and replay GrayMatter queued memory writes

### DIFF
--- a/src/services/graymatter/GrayMatterMemoryService.test.ts
+++ b/src/services/graymatter/GrayMatterMemoryService.test.ts
@@ -61,8 +61,13 @@ describe("GrayMatterMemoryService", () => {
     expect(result.status).not.toBe("written");
     expect(service.getPendingWrites()).toEqual([
       {
+        attempts: 0,
         content: "Retry this when api-0 is reachable.",
+        idempotencyKey:
+          "todo:2026-05-13T12:00:00.000Z:Retry this when api-0 is reachable.",
+        metadata: undefined,
         queuedAt: "2026-05-13T12:00:00.000Z",
+        tags: undefined,
         type: "todo",
       },
     ]);
@@ -97,5 +102,99 @@ describe("GrayMatterMemoryService", () => {
       type: "context",
     });
     expect(service.getPendingWrites()).toEqual([]);
+  });
+
+  it("loads queued writes from storage and replays them once", async () => {
+    const writeMemory = jest
+      .fn()
+      .mockResolvedValueOnce({ id: "memory-2" });
+    const savePendingWrites = jest.fn(async () => undefined);
+    const service = new GrayMatterMemoryService({
+      loadPendingWrites: async () => [
+        {
+          content: "Queued while offline.",
+          idempotencyKey: "todo:1",
+          queuedAt: "2026-05-13T11:59:00.000Z",
+          type: "todo",
+        },
+      ],
+      now: () => new Date("2026-05-13T12:00:00.000Z"),
+      savePendingWrites,
+      writeMemory,
+    });
+
+    await service.replayPendingWrites();
+
+    expect(writeMemory).toHaveBeenCalledWith({
+      content: "Queued while offline.",
+      metadata: undefined,
+      tags: undefined,
+      type: "todo",
+    });
+    expect(service.getPendingWrites()).toEqual([]);
+    expect(savePendingWrites).toHaveBeenCalledWith([]);
+  });
+
+  it("keeps queued writes for auth/quota failures and tracks replay attempts", async () => {
+    const service = new GrayMatterMemoryService({
+      loadPendingWrites: async () => [
+        {
+          content: "Needs credits",
+          idempotencyKey: "todo:2",
+          queuedAt: "2026-05-13T11:59:00.000Z",
+          type: "todo",
+        },
+      ],
+      now: () => new Date("2026-05-13T12:00:00.000Z"),
+      writeMemory: jest.fn(async () => {
+        throw new GrayMatterClientError("Need credits", "quota", 402);
+      }),
+    });
+
+    await service.replayPendingWrites();
+
+    expect(service.getPendingWrites()).toEqual([
+      {
+        attempts: 1,
+        content: "Needs credits",
+        idempotencyKey: "todo:2",
+        lastError: "Need credits",
+        lastErrorKind: "quota",
+        lastTriedAt: "2026-05-13T12:00:00.000Z",
+        queuedAt: "2026-05-13T11:59:00.000Z",
+        type: "todo",
+      },
+    ]);
+  });
+
+  it("redacts sensitive metadata keys before persisting queued writes", async () => {
+    const savePendingWrites = jest.fn(async () => undefined);
+    const service = new GrayMatterMemoryService({
+      now: () => new Date("2026-05-13T12:00:00.000Z"),
+      savePendingWrites,
+      writeMemory: jest.fn(async () => {
+        throw new GrayMatterClientError(
+          "GrayMatter is unavailable.",
+          "unavailable",
+          503,
+        );
+      }),
+    });
+
+    await service.writeMemory({
+      content: "Persist with safe metadata",
+      metadata: {
+        apiKey: "secret",
+        source: "valoride",
+      },
+      type: "context",
+    });
+
+    expect(service.getPendingWrites()[0]?.metadata).toEqual({ source: "valoride" });
+    expect(savePendingWrites).toHaveBeenCalledWith([
+      expect.objectContaining({
+        metadata: { source: "valoride" },
+      }),
+    ]);
   });
 });

--- a/src/services/graymatter/GrayMatterMemoryService.ts
+++ b/src/services/graymatter/GrayMatterMemoryService.ts
@@ -7,6 +7,11 @@ import {
 export type GrayMatterWriteStatus = "failed" | "queued" | "written";
 
 export interface PendingGrayMatterWrite extends GrayMatterMemoryInput {
+  attempts?: number;
+  idempotencyKey: string;
+  lastError?: string;
+  lastErrorKind?: GrayMatterErrorKind;
+  lastTriedAt?: string;
   queuedAt: string;
 }
 
@@ -34,22 +39,42 @@ export interface GrayMatterTranscriptSummary {
 }
 
 export interface GrayMatterMemoryServiceOptions {
+  loadPendingWrites?: () => Promise<PendingGrayMatterWrite[] | undefined>;
   now?: () => Date;
+  savePendingWrites?: (writes: PendingGrayMatterWrite[]) => Promise<void>;
   writeMemory: (input: GrayMatterMemoryInput) => Promise<unknown>;
 }
 
 export class GrayMatterMemoryService {
   private readonly now: () => Date;
   private readonly pendingWrites: PendingGrayMatterWrite[] = [];
+  private readonly ready: Promise<void>;
   private readonly writes: GrayMatterTranscriptWrite[] = [];
 
   constructor(private readonly options: GrayMatterMemoryServiceOptions) {
     this.now = options.now ?? (() => new Date());
+    this.ready = this.loadPendingWrites();
+  }
+
+  private async loadPendingWrites(): Promise<void> {
+    const loaded = await this.options.loadPendingWrites?.();
+    if (!loaded?.length) {
+      return;
+    }
+    this.pendingWrites.push(...loaded.map(sanitizePendingWrite));
+  }
+
+  private async persistPendingWrites(): Promise<void> {
+    if (!this.options.savePendingWrites) {
+      return;
+    }
+    await this.options.savePendingWrites(this.getPendingWrites());
   }
 
   async writeMemory(
     input: GrayMatterMemoryInput,
   ): Promise<GrayMatterMemoryWriteResult> {
+    await this.ready;
     const at = this.now().toISOString();
 
     try {
@@ -72,14 +97,17 @@ export class GrayMatterMemoryService {
         error instanceof GrayMatterClientError ? error : undefined;
       const message =
         error instanceof Error ? error.message : "GrayMatter write failed.";
-      const shouldQueue = clientError?.kind === "unavailable";
+      const shouldQueue = isRetryableKind(clientError?.kind);
       const status: GrayMatterWriteStatus = shouldQueue ? "queued" : "failed";
 
       if (shouldQueue) {
-        this.pendingWrites.push({
+        this.pendingWrites.push(sanitizePendingWrite({
           ...input,
+          attempts: 0,
+          idempotencyKey: createIdempotencyKey(input, at),
           queuedAt: at,
-        });
+        }));
+        await this.persistPendingWrites();
       }
 
       this.writes.push({
@@ -107,6 +135,61 @@ export class GrayMatterMemoryService {
     }));
   }
 
+  async replayPendingWrites(): Promise<void> {
+    await this.ready;
+    const snapshot = [...this.pendingWrites];
+    this.pendingWrites.length = 0;
+
+    for (const write of snapshot) {
+      const replayInput: GrayMatterMemoryInput = {
+        content: write.content,
+        metadata: write.metadata,
+        tags: write.tags,
+        type: write.type,
+      };
+      const at = this.now().toISOString();
+
+      try {
+        const response = await this.options.writeMemory(replayInput);
+        this.writes.push({
+          at,
+          id: getMemoryId(response),
+          status: "written",
+          tags: write.tags,
+          type: write.type,
+        });
+      } catch (error) {
+        const clientError =
+          error instanceof GrayMatterClientError ? error : undefined;
+        const message =
+          error instanceof Error ? error.message : "GrayMatter write failed.";
+        const shouldQueue = isRetryableKind(clientError?.kind);
+
+        this.writes.push({
+          at,
+          error: message,
+          status: shouldQueue ? "queued" : "failed",
+          tags: write.tags,
+          type: write.type,
+        });
+
+        if (shouldQueue) {
+          this.pendingWrites.push(
+            sanitizePendingWrite({
+              ...write,
+              attempts: (write.attempts ?? 0) + 1,
+              lastError: message,
+              lastErrorKind: clientError?.kind ?? "unavailable",
+              lastTriedAt: at,
+            }),
+          );
+        }
+      }
+    }
+
+    await this.persistPendingWrites();
+  }
+
   getTranscriptSummary(): GrayMatterTranscriptSummary {
     return {
       pendingWrites: this.pendingWrites.length,
@@ -118,6 +201,39 @@ export class GrayMatterMemoryService {
     };
   }
 }
+
+const SENSITIVE_METADATA_KEY = /(secret|token|password|api[-_]?key|authorization)/iu;
+
+const sanitizePendingWrite = (
+  write: PendingGrayMatterWrite,
+): PendingGrayMatterWrite => ({
+  ...write,
+  metadata: sanitizeMetadata(write.metadata),
+});
+
+const sanitizeMetadata = (
+  metadata?: Record<string, unknown>,
+): Record<string, unknown> | undefined => {
+  if (!metadata) {
+    return undefined;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (SENSITIVE_METADATA_KEY.test(key)) {
+      continue;
+    }
+    sanitized[key] = value;
+  }
+
+  return sanitized;
+};
+
+const isRetryableKind = (kind?: GrayMatterErrorKind) =>
+  kind === "unavailable" || kind === "quota" || kind === "unauthenticated";
+
+const createIdempotencyKey = (input: GrayMatterMemoryInput, at: string) =>
+  `${input.type}:${at}:${input.content.slice(0, 48)}`;
 
 const getMemoryId = (response: unknown): string | undefined => {
   if (!response || typeof response !== "object") {


### PR DESCRIPTION
## Summary\n- add durable pending-write load/save hooks to GrayMatterMemoryService\n- persist queued writes with idempotency key + retry metadata and redact sensitive metadata fields\n- add replayPendingWrites() with retry classification for unavailable/auth/quota failures\n- extend unit tests for reload replay, retry metadata, and redaction behavior\n\n## Testing\n- npx jest src/services/graymatter/GrayMatterMemoryService.test.ts --runInBand\n\nRefs: https://github.com/ValkyrLabs/ValkyrAI/issues/2978