### PR TITLE
Secure ValorIDE auth callback exchange

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,8 @@ import { initializeTestMode, cleanupTestMode } from "./services/test/TestMode";
 import { registerUrlCommands } from "./commands/urlCommands";
 import { registerAliasCommands } from "./commands/aliasCommands";
 import { StartupAuthService } from "./services/auth/StartupAuthService";
+import { AuthCodeExchangeService } from "./services/auth/AuthCodeExchangeService";
+import { parseAuthCallbackQuery } from "./services/auth/AuthCallbackSecurity";
 import { initializePromptService } from "./services/promptService";
 import { initializeMemoryBankLoader } from "./services/memoryBankLoader";
 import { initializeLLMContextInjector } from "./services/llmContextInjector";
@@ -530,22 +532,16 @@ export function activate(context: vscode.ExtensionContext) {
 
   // URI Handler
   const handleUri = async (uri: vscode.Uri) => {
-    console.log("URI Handler called with:", {
-      path: uri.path,
-      query: uri.query,
-      scheme: uri.scheme,
-    });
-
     const path = uri.path;
-    // Guard against missing query to avoid calling replace on undefined
-    const rawQuery = uri.query || "";
-    const query = new URLSearchParams(rawQuery.replace(/\+/g, "%2B"));
     const visibleWebview = WebviewProvider.getVisibleInstance();
     if (!visibleWebview) {
       return;
     }
     switch (path) {
       case "/openrouter": {
+        const query = new URLSearchParams(
+          (uri.query || "").replace(/\+/g, "%2B"),
+        );
         const code = query.get("code");
         if (code) {
           await visibleWebview?.controller.handleOpenRouterCallback(code);
@@ -553,47 +549,51 @@ export function activate(context: vscode.ExtensionContext) {
         break;
       }
       case "/auth": {
-        const token = query.get("token");
-        const state = query.get("state");
-        const apiKey = query.get("apiKey");
-        const authenticatedPrincipal = query.get("authenticatedPrincipal");
+        const callback = parseAuthCallbackQuery(uri);
+        Logger.log(
+          `Auth callback received: ${JSON.stringify(callback.diagnostics)}`,
+        );
 
-        console.log("Auth callback received:", {
-          token: token,
-          state: state,
-          apiKey: apiKey,
-          authenticatedPrincipal: authenticatedPrincipal,
-        });
+        if (callback.hasLegacySecretParams) {
+          vscode.window.showErrorMessage(
+            "ValorIDE rejected an insecure auth callback. Please retry sign-in to use the secure code exchange flow.",
+          );
+          return;
+        }
 
-        // Validate state parameter
-        if (!(await visibleWebview?.controller.validateAuthState(state))) {
+        // Validate state parameter before exchanging the one-time code.
+        if (
+          !(await visibleWebview?.controller.validateAuthState(callback.state))
+        ) {
           vscode.window.showErrorMessage("Invalid auth state");
           return;
         }
 
-        if (token && apiKey) {
-          let parsedUser;
-          try {
-            parsedUser = authenticatedPrincipal
-              ? JSON.parse(decodeURIComponent(authenticatedPrincipal))
-              : undefined;
-          } catch (error) {
-            console.warn("Failed to parse authenticatedPrincipal:", error);
-          }
-
-          // Use StartupAuthService to handle login persistently
-          const startupAuthService = StartupAuthService.getInstance(context);
-          await startupAuthService.handleSuccessfulLogin(
-            { jwtToken: token, apiKey },
-            parsedUser,
+        if (!callback.code || !callback.state) {
+          vscode.window.showErrorMessage(
+            "ValorIDE auth callback did not include a valid one-time code.",
           );
-
-          await visibleWebview?.controller.handleAuthCallback(
-            token,
-            apiKey,
-            parsedUser,
-          );
+          return;
         }
+
+        const exchangeService = new AuthCodeExchangeService();
+        const authResult = await exchangeService.exchangeCode(
+          callback.code,
+          callback.state,
+        );
+
+        // Use StartupAuthService to handle login persistently via VS Code SecretStorage.
+        const startupAuthService = StartupAuthService.getInstance(context);
+        await startupAuthService.handleSuccessfulLogin(
+          authResult.tokens,
+          authResult.user,
+        );
+
+        await visibleWebview?.controller.handleAuthCallback(
+          authResult.tokens.jwtToken,
+          authResult.tokens.apiKey || "",
+          authResult.user,
+        );
         break;
       }
       default:

--- a/src/services/auth/AuthCallbackSecurity.test.ts
+++ b/src/services/auth/AuthCallbackSecurity.test.ts
@@ -1,0 +1,45 @@
+import { expect } from "chai";
+import {
+  containsForbiddenAuthLogField,
+  parseAuthCallbackQuery,
+} from "./AuthCallbackSecurity";
+
+describe("AuthCallbackSecurity", () => {
+  it("redacts auth callback diagnostics to non-secret booleans", () => {
+    const callback = parseAuthCallbackQuery({
+      path: "/auth",
+      scheme: "vscode",
+      query:
+        "code=one-time-code&state=expected-state&token=jwt-value&apiKey=key-value&authenticatedPrincipal=%7B%7D",
+    });
+
+    expect(callback.code).to.equal("one-time-code");
+    expect(callback.state).to.equal("expected-state");
+    expect(callback.hasLegacySecretParams).to.equal(true);
+    expect(callback.diagnostics).to.deep.equal({
+      path: "/auth",
+      scheme: "vscode",
+      hasQuery: true,
+      hasCode: true,
+      hasState: true,
+      hasLegacySecretParams: true,
+      hasUserPayload: true,
+    });
+    expect(JSON.stringify(callback.diagnostics)).not.to.contain("jwt-value");
+    expect(JSON.stringify(callback.diagnostics)).not.to.contain("key-value");
+    expect(containsForbiddenAuthLogField(callback.diagnostics)).to.equal(false);
+  });
+
+  it("keeps direct credential query callbacks out of the accepted path", () => {
+    const callback = parseAuthCallbackQuery({
+      path: "/auth",
+      scheme: "vscode",
+      query: "token=jwt-value&apiKey=key-value&state=expected-state",
+    });
+
+    expect(callback.code).to.equal(null);
+    expect(callback.hasLegacySecretParams).to.equal(true);
+    expect(callback.diagnostics.hasLegacySecretParams).to.equal(true);
+    expect(containsForbiddenAuthLogField(callback.diagnostics)).to.equal(false);
+  });
+});

--- a/src/services/auth/AuthCallbackSecurity.ts
+++ b/src/services/auth/AuthCallbackSecurity.ts
@@ -1,0 +1,51 @@
+export interface AuthCallbackDiagnostics {
+  path: string;
+  scheme: string;
+  hasQuery: boolean;
+  hasCode: boolean;
+  hasState: boolean;
+  hasLegacySecretParams: boolean;
+  hasUserPayload: boolean;
+}
+
+export interface AuthCallbackQuery {
+  code: string | null;
+  state: string | null;
+  hasLegacySecretParams: boolean;
+  diagnostics: AuthCallbackDiagnostics;
+}
+
+const LEGACY_SECRET_QUERY_KEYS = ["token", "apiKey", "jwt", "Authorization"];
+
+export function parseAuthCallbackQuery(uri: {
+  path: string;
+  query?: string;
+  scheme: string;
+}): AuthCallbackQuery {
+  const rawQuery = uri.query || "";
+  const query = new URLSearchParams(rawQuery.replace(/\+/g, "%2B"));
+  const hasLegacySecretParams = LEGACY_SECRET_QUERY_KEYS.some((key) =>
+    query.has(key),
+  );
+
+  return {
+    code: query.get("code"),
+    state: query.get("state"),
+    hasLegacySecretParams,
+    diagnostics: {
+      path: uri.path,
+      scheme: uri.scheme,
+      hasQuery: rawQuery.length > 0,
+      hasCode: query.has("code"),
+      hasState: query.has("state"),
+      hasLegacySecretParams,
+      hasUserPayload: query.has("authenticatedPrincipal"),
+    },
+  };
+}
+
+export function containsForbiddenAuthLogField(payload: unknown): boolean {
+  const forbidden = ["token", "apikey", "jwt", "authorization"];
+  const serialized = JSON.stringify(payload).toLowerCase();
+  return forbidden.some((term) => serialized.includes(term));
+}

--- a/src/services/auth/AuthCodeExchangeService.ts
+++ b/src/services/auth/AuthCodeExchangeService.ts
@@ -1,0 +1,43 @@
+import axios from "axios";
+import { getValkyraiBasePath } from "@utils/serverValkyraiHost";
+import { AuthenticatedUser, AuthTokens } from "./TokenStorageService";
+
+export interface AuthCodeExchangeResult {
+  tokens: AuthTokens;
+  user?: AuthenticatedUser;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export class AuthCodeExchangeService {
+  async exchangeCode(
+    code: string,
+    state: string,
+  ): Promise<AuthCodeExchangeResult> {
+    const baseUrl = getValkyraiBasePath();
+    const response = await axios.post(
+      `${baseUrl}/auth/valoride/code-exchange`,
+      { code, state },
+      { timeout: 10000 },
+    );
+
+    const data = response.data || {};
+    const jwtToken = readString(data.jwtToken) || readString(data.token);
+    if (!jwtToken) {
+      throw new Error("Auth code exchange did not return a session token");
+    }
+
+    return {
+      tokens: {
+        jwtToken,
+        apiKey: readString(data.apiKey),
+        refreshToken: readString(data.refreshToken),
+        expiresAt:
+          typeof data.expiresAt === "number" ? data.expiresAt : undefined,
+      },
+      user: data.user || data.authenticatedPrincipal,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- replace direct auth callback credential parsing with a one-time code exchange service
- redact URI callback diagnostics to safe booleans and reject legacy token/apiKey query callbacks
- add focused auth callback redaction tests

## Tests
- yarn eslint src/extension.ts src/services/auth/AuthCallbackSecurity.ts src/services/auth/AuthCodeExchangeService.ts src/services/auth/AuthCallbackSecurity.test.ts
- ./node_modules/.bin/tsc -p /tmp/tsconfig-authcallback-3092.json
- ./node_modules/.bin/mocha .tmp-authcallback-3092-out/src/services/auth/AuthCallbackSecurity.test.js

Note: yarn run compile-tests still fails on existing baseline tsconfig/test harness issues unrelated to this change (missing global jest/expect declarations and webview-ui rootDir/import.meta errors). yarn run check-types was attempted but the process was SIGKILLed before completion.