### PR TITLE
feat: turn capability failures into recovery actions

### DIFF
--- a/webview-ui/src/components/account/AccountView.tsx
+++ b/webview-ui/src/components/account/AccountView.tsx
@@ -45,6 +45,11 @@ import LoadingSpinner from "@thorapi/components/LoadingSpinner";
 import { useCommunicationService } from "@thorapi/context/CommunicationServiceContext";
 import UserPreferences from "./UserPreferences";
 import BuyCredits from "@thorapi/components/BuyCredits";
+import CapabilityCommandCenter, {
+  CapabilityAction,
+  CapabilityCardModel,
+  CapabilitySnapshot,
+} from "../agentic/CapabilityCommandCenter";
 import {
   storeJwtToken,
   useAccessControl,
@@ -56,18 +61,24 @@ type AccountViewProps = {
   onDone: () => void;
   serverConsoleNeedsAttention: boolean;
   initialActiveTab?:
-  | "login"
-  | "account"
-  | "applications"
-  | "generatedFiles"
-  | "userPreferences"
-  | "serverConsole";
+    | "login"
+    | "account"
+    | "applications"
+    | "generatedFiles"
+    | "userPreferences"
+    | "serverConsole";
   onConsumeInitialActiveTab?: () => void;
   onClearServerConsoleNeedsAttention: () => void;
 };
 
-const AccountView = ({ onDone, serverConsoleNeedsAttention, onClearServerConsoleNeedsAttention, initialActiveTab, onConsumeInitialActiveTab }: AccountViewProps) => {
-  const { userInfo, authenticatedUser, isLoggedIn, jwtToken } =
+const AccountView = ({
+  onDone,
+  serverConsoleNeedsAttention,
+  onClearServerConsoleNeedsAttention,
+  initialActiveTab,
+  onConsumeInitialActiveTab,
+}: AccountViewProps) => {
+  const { userInfo, authenticatedUser, isLoggedIn, jwtToken, mcpServers } =
     useExtensionState();
   // Read live messages once at top-level to respect Hooks rules
   const { valorideMessages } = useExtensionState();
@@ -103,7 +114,12 @@ const AccountView = ({ onDone, serverConsoleNeedsAttention, onClearServerConsole
 
   // Default to login tab when unauthenticated, otherwise account
   const [activeTab, setActiveTab] = useState<
-    "login" | "account" | "applications" | "generatedFiles" | "userPreferences" | "serverConsole"
+    | "login"
+    | "account"
+    | "applications"
+    | "generatedFiles"
+    | "userPreferences"
+    | "serverConsole"
   >(authed ? "account" : "login");
 
   // Keep active tab in sync with authentication state
@@ -300,6 +316,125 @@ const AccountView = ({ onDone, serverConsoleNeedsAttention, onClearServerConsole
         : "Offline";
   const kind = ready ? "ok" : hasError ? "error" : "warn";
 
+  const effectiveBalance = useMemo(() => {
+    const rawBalance = balanceData?.currentBalance ?? 0;
+    return Math.max(0, rawBalance - (apiMetrics.totalCost || 0));
+  }, [apiMetrics.totalCost, balanceData?.currentBalance]);
+
+  const capabilitySnapshots = useMemo<CapabilitySnapshot[]>(() => {
+    const graymatterStatus: CapabilitySnapshot["status"] = !authed
+      ? "unauthenticated"
+      : hasError
+        ? "unavailable"
+        : effectiveBalance <= 0
+          ? "quotaBlocked"
+          : effectiveBalance < 5
+            ? "lowCredit"
+            : "ready";
+
+    return [
+      {
+        id: "graymatter",
+        label: "GrayMatter memory",
+        status: graymatterStatus,
+        detail:
+          graymatterStatus === "ready"
+            ? "Memory, entitlement, and credit prerequisites look usable from the current webview state."
+            : undefined,
+        latestFailure: hasError
+          ? {
+              command: "capability.discovery",
+              message:
+                "Communication service reported an error. Open diagnostics before retrying.",
+            }
+          : effectiveBalance <= 0 && authed
+            ? {
+                command: "memory.write",
+                message:
+                  "Credits are depleted. Add credits or upgrade before retrying.",
+              }
+            : undefined,
+      },
+      {
+        id: "mcp",
+        label: "MCP tools",
+        status: mcpServers.length > 0 ? "ready" : "disconnected",
+        detail:
+          mcpServers.length > 0
+            ? `${mcpServers.length} MCP server${mcpServers.length === 1 ? "" : "s"} visible to ValorIDE.`
+            : undefined,
+      },
+      {
+        id: "swarm",
+        label: "SWARM handoff",
+        status: ready ? "ready" : "offline",
+        detail: ready
+          ? value
+          : "SWARM presence is not fully online. Use diagnostics or retry discovery.",
+      },
+    ];
+  }, [authed, effectiveBalance, hasError, mcpServers.length, ready, value]);
+
+  const handleCapabilityAction = useCallback(
+    async (action: CapabilityAction, capability: CapabilityCardModel) => {
+      const activationEvent = {
+        type: "valoride:capability-action",
+        payload: {
+          source: "capability-command-center",
+          action,
+          capability: capability.id,
+          status: capability.status,
+          timestamp: Date.now(),
+        },
+        messageId: Math.random().toString(36).slice(2, 12),
+        timestamp: Date.now(),
+      };
+
+      window.dispatchEvent(
+        new CustomEvent("websocket-send", { detail: activationEvent }),
+      );
+
+      switch (action) {
+        case "signIn":
+          setActiveTab("login");
+          vscode.postMessage({ type: "accountLoginClicked" });
+          break;
+        case "setupGrayMatter":
+          setActiveTab("account");
+          vscode.postMessage({ type: "showAccountViewClicked" });
+          break;
+        case "buyCredits":
+          setActiveTab("account");
+          break;
+        case "teamPlan":
+          vscode.postMessage({
+            type: "openInBrowser",
+            text: "https://valkyrlabs.com/pricing?utm_source=valoride&utm_campaign=capability-command-center&intent=team-plan",
+          });
+          break;
+        case "openMcpMarketplace":
+          vscode.postMessage({ type: "showMcpView", tab: "marketplace" });
+          break;
+        case "openDiagnostics":
+          setActiveTab("serverConsole");
+          vscode.postMessage({
+            type: "displayVSCodeInfo",
+            text: `${capability.label} diagnostics opened from Capability Command Center.`,
+          });
+          break;
+        case "retry":
+          vscode.postMessage({ type: "fetchLatestMcpServersFromHub" });
+          await refetchBalance();
+          if (authed) {
+            refetchUsage();
+            refetchPayments();
+          }
+          break;
+      }
+    },
+    [authed, refetchBalance, refetchPayments, refetchUsage],
+  );
+
   return (
     <div
       style={{
@@ -312,6 +447,11 @@ const AccountView = ({ onDone, serverConsoleNeedsAttention, onClearServerConsole
       }}
     >
       <SystemAlerts />
+
+      <CapabilityCommandCenter
+        snapshots={capabilitySnapshots}
+        onAction={handleCapabilityAction}
+      />
 
       {peers.length > 0 && (
         <div className="border border-solid border-(--vscode-panel-border) rounded-md p-[10px] mb-3 bg-[var(--vscode-panel-background)] text-[var(--vscode-foreground)]">
@@ -496,23 +636,12 @@ const AccountView = ({ onDone, serverConsoleNeedsAttention, onClearServerConsole
                   <LoadingSpinner label="Loading balance..." size={28} />
                 ) : (
                   <>
-                    {(() => {
-                      const rawBalance = balanceData?.currentBalance ?? 0;
-                      const effectiveBalance = Math.max(
-                        0,
-                        rawBalance - (apiMetrics.totalCost || 0),
-                      );
-                      return (
-                        <>
-                          <span>$</span>
-                          <CountUp
-                            end={effectiveBalance}
-                            duration={0.66}
-                            decimals={2}
-                          />
-                        </>
-                      );
-                    })()}
+                    <span>$</span>
+                    <CountUp
+                      end={effectiveBalance}
+                      duration={0.66}
+                      decimals={2}
+                    />
                     <VSCodeButton
                       appearance="icon"
                       className="mt-1"

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@vscode/webview-ui-toolkit/react", () => ({
+  VSCodeButton: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+import CapabilityCommandCenter, {
+  CapabilitySnapshot,
+  deriveCapabilityCards,
+} from "./CapabilityCommandCenter";
+
+const degradedSnapshots: CapabilitySnapshot[] = [
+  { id: "graymatter", label: "GrayMatter", status: "unauthenticated" },
+  { id: "graymatter", label: "GrayMatter RBAC", status: "rbacDenied" },
+  { id: "graymatter", label: "GrayMatter quota", status: "quotaBlocked" },
+  { id: "graymatter", label: "GrayMatter unavailable", status: "unavailable" },
+  { id: "mcp", label: "MCP", status: "disconnected" },
+  { id: "swarm", label: "SWARM", status: "offline" },
+];
+
+describe("CapabilityCommandCenter", () => {
+  it("maps every degraded capability state to a recovery or upsell action", () => {
+    const cards = deriveCapabilityCards(degradedSnapshots);
+
+    expect(
+      cards
+        .find((card) => card.status === "unauthenticated")
+        ?.actions.map((action) => action.action),
+    ).toContain("signIn");
+    expect(
+      cards
+        .find((card) => card.status === "rbacDenied")
+        ?.actions.map((action) => action.action),
+    ).toContain("teamPlan");
+    expect(
+      cards
+        .find((card) => card.status === "quotaBlocked")
+        ?.actions.map((action) => action.action),
+    ).toContain("buyCredits");
+    expect(
+      cards
+        .find((card) => card.status === "unavailable")
+        ?.actions.map((action) => action.action),
+    ).toContain("openDiagnostics");
+    expect(
+      cards
+        .find((card) => card.status === "disconnected")
+        ?.actions.map((action) => action.action),
+    ).toContain("openMcpMarketplace");
+    expect(
+      cards
+        .find((card) => card.status === "offline")
+        ?.actions.map((action) => action.action),
+    ).toContain("openDiagnostics");
+  });
+
+  it("renders latest command failure detail without secret-looking payloads", () => {
+    render(
+      <CapabilityCommandCenter
+        snapshots={[
+          {
+            id: "graymatter",
+            label: "GrayMatter",
+            status: "quotaBlocked",
+            latestFailure: {
+              command: "memory.write",
+              message: "Quota exceeded. Retry after adding credits.",
+            },
+          },
+        ]}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText(/Latest failure:/)).toBeInTheDocument();
+    expect(screen.getByText(/memory.write/)).toBeInTheDocument();
+    expect(screen.queryByText(/jwt|token|secret/i)).not.toBeInTheDocument();
+  });
+
+  it("emits attributed action context when a recovery button is clicked", async () => {
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+
+    render(
+      <CapabilityCommandCenter
+        snapshots={[{ id: "mcp", label: "MCP", status: "disconnected" }]}
+        onAction={onAction}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Open MCP marketplace/i }),
+    );
+
+    expect(onAction).toHaveBeenCalledWith(
+      "openMcpMarketplace",
+      expect.objectContaining({ id: "mcp", status: "disconnected" }),
+    );
+  });
+});

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
@@ -1,0 +1,310 @@
+import React from "react";
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+
+export type CapabilityId = "graymatter" | "mcp" | "swarm";
+
+export type CapabilityStatus =
+  | "ready"
+  | "unauthenticated"
+  | "rbacDenied"
+  | "quotaBlocked"
+  | "lowCredit"
+  | "unavailable"
+  | "disconnected"
+  | "offline";
+
+export type CapabilityAction =
+  | "signIn"
+  | "setupGrayMatter"
+  | "buyCredits"
+  | "teamPlan"
+  | "openMcpMarketplace"
+  | "openDiagnostics"
+  | "retry";
+
+export type LatestCommandFailure = {
+  command: string;
+  message: string;
+  occurredAt?: string;
+};
+
+export type CapabilitySnapshot = {
+  id: CapabilityId;
+  label: string;
+  status: CapabilityStatus;
+  detail?: string;
+  latestFailure?: LatestCommandFailure;
+};
+
+export type CapabilityActionModel = {
+  action: CapabilityAction;
+  label: string;
+  detail: string;
+  variant?: "primary" | "secondary";
+};
+
+export type CapabilityCardModel = CapabilitySnapshot & {
+  tone: "ready" | "warning" | "danger";
+  statusLabel: string;
+  actions: CapabilityActionModel[];
+};
+
+const STATUS_COPY: Record<
+  CapabilityStatus,
+  { label: string; tone: CapabilityCardModel["tone"] }
+> = {
+  ready: { label: "Ready", tone: "ready" },
+  unauthenticated: { label: "Sign in needed", tone: "warning" },
+  rbacDenied: { label: "RBAC blocked", tone: "danger" },
+  quotaBlocked: { label: "Quota blocked", tone: "danger" },
+  lowCredit: { label: "Low credits", tone: "warning" },
+  unavailable: { label: "Unavailable", tone: "danger" },
+  disconnected: { label: "Disconnected", tone: "warning" },
+  offline: { label: "Offline", tone: "warning" },
+};
+
+const ACTIONS_BY_STATUS: Record<CapabilityStatus, CapabilityActionModel[]> = {
+  ready: [
+    {
+      action: "retry",
+      label: "Refresh",
+      detail: "Refresh live capability state.",
+      variant: "secondary",
+    },
+  ],
+  unauthenticated: [
+    {
+      action: "signIn",
+      label: "Sign in",
+      detail: "Authenticate ValorIDE before using GrayMatter memory.",
+      variant: "primary",
+    },
+    {
+      action: "setupGrayMatter",
+      label: "Setup guide",
+      detail: "Open the account and activation path for GrayMatter setup.",
+      variant: "secondary",
+    },
+  ],
+  rbacDenied: [
+    {
+      action: "teamPlan",
+      label: "Team access",
+      detail:
+        "Open the team-plan path when your org role blocks memory writes.",
+      variant: "primary",
+    },
+    {
+      action: "openDiagnostics",
+      label: "Diagnostics",
+      detail: "Open diagnostics without exposing tokens or secrets.",
+      variant: "secondary",
+    },
+  ],
+  quotaBlocked: [
+    {
+      action: "buyCredits",
+      label: "Buy credits",
+      detail: "Recharge credits before retrying the failed capability.",
+      variant: "primary",
+    },
+    {
+      action: "teamPlan",
+      label: "Upgrade team plan",
+      detail: "Open plan upgrade options for sustained memory usage.",
+      variant: "secondary",
+    },
+  ],
+  lowCredit: [
+    {
+      action: "buyCredits",
+      label: "Add credits",
+      detail: "Top up before the next agentic command is blocked.",
+      variant: "primary",
+    },
+  ],
+  unavailable: [
+    {
+      action: "openDiagnostics",
+      label: "Diagnostics",
+      detail: "Open server-console diagnostics for the unavailable service.",
+      variant: "primary",
+    },
+    {
+      action: "retry",
+      label: "Retry",
+      detail: "Retry capability discovery after diagnostics.",
+      variant: "secondary",
+    },
+  ],
+  disconnected: [
+    {
+      action: "openMcpMarketplace",
+      label: "Open MCP marketplace",
+      detail: "Install or reconnect MCP tools from the marketplace.",
+      variant: "primary",
+    },
+    {
+      action: "retry",
+      label: "Retry connection",
+      detail: "Refresh installed MCP server state.",
+      variant: "secondary",
+    },
+  ],
+  offline: [
+    {
+      action: "openDiagnostics",
+      label: "Open diagnostics",
+      detail: "Inspect SWARM and server-console connectivity.",
+      variant: "primary",
+    },
+    {
+      action: "retry",
+      label: "Retry",
+      detail: "Retry SWARM presence discovery.",
+      variant: "secondary",
+    },
+  ],
+};
+
+const FALLBACK_DETAIL: Record<CapabilityId, string> = {
+  graymatter:
+    "Durable memory needs auth, entitlement, credits, and API reachability.",
+  mcp: "MCP needs at least one connected server before tools can recover workflows.",
+  swarm: "SWARM needs local and ValkyrAI connectivity for multi-agent handoff.",
+};
+
+export function deriveCapabilityCards(
+  snapshots: CapabilitySnapshot[],
+): CapabilityCardModel[] {
+  return snapshots.map((snapshot) => {
+    const copy = STATUS_COPY[snapshot.status];
+    return {
+      ...snapshot,
+      tone: copy.tone,
+      statusLabel: copy.label,
+      detail: snapshot.detail || FALLBACK_DETAIL[snapshot.id],
+      actions: ACTIONS_BY_STATUS[snapshot.status],
+    };
+  });
+}
+
+type CapabilityCommandCenterProps = {
+  snapshots: CapabilitySnapshot[];
+  onAction: (action: CapabilityAction, capability: CapabilityCardModel) => void;
+};
+
+export default function CapabilityCommandCenter({
+  snapshots,
+  onAction,
+}: CapabilityCommandCenterProps) {
+  const cards = deriveCapabilityCards(snapshots);
+
+  return (
+    <section
+      aria-label="Capability Command Center"
+      style={{
+        border: "1px solid var(--vscode-panel-border)",
+        borderRadius: 10,
+        padding: 12,
+        margin: "0 0 16px",
+        background: "var(--vscode-editor-background)",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+        <div>
+          <h3 style={{ margin: 0 }}>Capability Command Center</h3>
+          <p
+            style={{
+              margin: "4px 0 12px",
+              color: "var(--vscode-descriptionForeground)",
+              fontSize: 12,
+            }}
+          >
+            Recovery actions stay inside ValorIDE and avoid exposing raw auth
+            state.
+          </p>
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gap: 10 }}>
+        {cards.map((card) => (
+          <article
+            key={card.id}
+            data-testid={`capability-card-${card.id}`}
+            style={{
+              border: "1px solid var(--vscode-panel-border)",
+              borderLeft: `4px solid ${
+                card.tone === "ready"
+                  ? "var(--vscode-testing-iconPassed)"
+                  : card.tone === "danger"
+                    ? "var(--vscode-testing-iconFailed)"
+                    : "var(--vscode-testing-iconQueued)"
+              }`,
+              borderRadius: 8,
+              padding: 10,
+              background: "var(--vscode-sideBar-background)",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                gap: 10,
+              }}
+            >
+              <strong>{card.label}</strong>
+              <span
+                aria-label={`${card.label} status`}
+                style={{
+                  border: "1px solid var(--vscode-panel-border)",
+                  borderRadius: 999,
+                  padding: "2px 8px",
+                  fontSize: 11,
+                }}
+              >
+                {card.statusLabel}
+              </span>
+            </div>
+            <p
+              style={{
+                margin: "6px 0",
+                color: "var(--vscode-descriptionForeground)",
+              }}
+            >
+              {card.detail}
+            </p>
+            {card.latestFailure && (
+              <div
+                role="note"
+                title={card.latestFailure.message}
+                style={{
+                  fontSize: 12,
+                  color: "var(--vscode-descriptionForeground)",
+                  marginBottom: 8,
+                }}
+              >
+                Latest failure: <strong>{card.latestFailure.command}</strong> —{" "}
+                {card.latestFailure.message}
+              </div>
+            )}
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+              {card.actions.map((action) => (
+                <VSCodeButton
+                  key={`${card.id}-${action.action}`}
+                  appearance={
+                    action.variant === "primary" ? "primary" : "secondary"
+                  }
+                  title={action.detail}
+                  onClick={() => onAction(action.action, card)}
+                >
+                  {action.label}
+                </VSCodeButton>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a ValorIDE Capability Command Center with recovery and upsell actions for GrayMatter, MCP, and SWARM degraded states
- Wire account view actions to existing sign-in, account, MCP marketplace, diagnostics, retry, and team-plan routes
- Track activation/upsell intent with capability/status context while avoiding secret/token display

## Tests
- npm test -- --run src/components/agentic/CapabilityCommandCenter.test.tsx
- npm run build (blocked by existing missing webview deps such as @reduxjs/toolkit/query/react, redux-query, react-redux)
- npm run lint -- --quiet (blocked by existing eslint.config.js __dirname under type=module)

Refs ValkyrLabs/ValkyrAI#3083