### PR TITLE
feat(credits): route ValorIDE top-ups through Stripe checkout

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -28,6 +28,7 @@ import { ValorIDEAccountService } from "@services/account/ValorIDEAccountService
 import { BrowserSession } from "@services/browser/BrowserSession";
 import { McpHub } from "@services/mcp/McpHub";
 import { searchWorkspaceFiles } from "@services/search/file-search";
+import { telemetryService } from "@services/telemetry/TelemetryService";
 
 import { getLLMPromptService } from "@services/llmPromptService";
 import { getSwarmPromptBroadcaster } from "@services/swarmPromptBroadcaster";
@@ -841,6 +842,28 @@ export class Controller {
           await openUrlWithSimpleBrowser(message.url);
         }
         break;
+      case "creditCheckoutEvent": {
+        const allowedKeys = new Set([
+          "amountCents",
+          "creditsAmountCents",
+          "currency",
+          "errorCode",
+          "productType",
+          "source",
+          "state",
+          "surface",
+        ]);
+        const sanitizedProperties = Object.fromEntries(
+          Object.entries(message.telemetryProperties ?? {}).filter(([key]) =>
+            allowedKeys.has(key),
+          ),
+        );
+        telemetryService.capture({
+          event: message.telemetryEvent || "valoride_credit_checkout_event",
+          properties: sanitizedProperties,
+        });
+        break;
+      }
       case "fetchOpenGraphData":
         this.fetchOpenGraphData(message.text!);
         break;

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -105,6 +105,7 @@ export interface WebviewMessage {
   | "uploadOpenAPISpec"
   | "uploadOpenAPISpecResult"
   | "remoteCodingSessionCommand"
+  | "creditCheckoutEvent"
   | "openFile";
 
   // | "relaunchChromeDebugMode"
@@ -136,6 +137,8 @@ export interface WebviewMessage {
   customToken?: string;
   // For openInBrowser
   url?: string;
+  telemetryEvent?: string;
+  telemetryProperties?: Record<string, unknown>;
   planActSeparateModelsSetting?: boolean;
   telemetrySetting?: TelemetrySetting;
   customInstructionsSetting?: string;

--- a/webview-ui/src/components/BuyCredits/BuyCredits.test.tsx
+++ b/webview-ui/src/components/BuyCredits/BuyCredits.test.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import BuyCredits from "./index";
+
+const mockCreateCheckoutSession = vi.fn();
+const mockPostMessage = vi.fn();
+
+vi.mock("@thorapi/utils/vscode", () => ({
+  vscode: {
+    postMessage: (message: any) => mockPostMessage(message),
+  },
+}));
+
+vi.mock("../../services/creditsApi", () => ({
+  useCreateCreditCheckoutSessionMutation: () => [mockCreateCheckoutSession],
+}));
+
+vi.mock("@valkyr/component-library/CoolButton", () => ({
+  __esModule: true,
+  default: ({ children, customStyle, ...props }: any) => (
+    <button style={customStyle} {...props}>
+      {children}
+    </button>
+  ),
+}), { virtual: true });
+
+vi.mock("react-bootstrap", () => {
+  const Card = ({ children, ...props }: any) => <section {...props}>{children}</section>;
+  Card.Header = ({ children, ...props }: any) => <div {...props}>{children}</div>;
+  Card.Body = ({ children, ...props }: any) => <div {...props}>{children}</div>;
+
+  const Form = ({ children, ...props }: any) => <form {...props}>{children}</form>;
+  Form.Group = ({ children, ...props }: any) => <div {...props}>{children}</div>;
+  Form.Label = ({ children, ...props }: any) => <label {...props}>{children}</label>;
+  Form.Text = ({ children, ...props }: any) => <small {...props}>{children}</small>;
+  Form.Control = (props: any) => <input aria-label="Amount (USD)" {...props} />;
+
+  const InputGroup = ({ children, ...props }: any) => <div {...props}>{children}</div>;
+  InputGroup.Text = ({ children, ...props }: any) => <span {...props}>{children}</span>;
+
+  const Button = ({ children, ...props }: any) => <button {...props}>{children}</button>;
+  const Alert = ({ children, ...props }: any) => <div role="alert" {...props}>{children}</div>;
+
+  return { __esModule: true, Card, Form, InputGroup, Button, Alert };
+}, { virtual: true });
+
+const principal = { id: "principal-123" };
+
+beforeEach(() => {
+  mockCreateCheckoutSession.mockReset();
+  mockPostMessage.mockReset();
+  vi.stubGlobal("crypto", { randomUUID: () => "checkout-idempotency-key" });
+});
+
+describe("BuyCredits", () => {
+  it("starts Stripe Checkout instead of booking direct payment credits", async () => {
+    mockCreateCheckoutSession.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({ checkout_url: "https://checkout.stripe.test/session" }),
+    });
+
+    render(<BuyCredits authenticatedPrincipal={principal} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /buy \$10 credits/i }));
+
+    await waitFor(() => expect(mockCreateCheckoutSession).toHaveBeenCalledTimes(1));
+    expect(mockCreateCheckoutSession.mock.calls[0][0]).toMatchObject({
+      amountCents: 1000,
+      creditsAmountCents: 1000,
+      currency: "usd",
+      itemName: "ValorIDE $10 Credit Top-up",
+      productType: "credits",
+      sku: "valoride-credits-usd-10",
+    });
+    expect(mockCreateCheckoutSession.mock.calls[0][0]).not.toHaveProperty("payment");
+
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: "openInBrowser",
+      url: "https://checkout.stripe.test/session",
+    });
+    expect(screen.getByText(/Stripe Checkout opened/i)).toBeInTheDocument();
+    expect(screen.getByText(/Credits post after webhook reconciliation/i)).toBeInTheDocument();
+  });
+
+  it("surfaces checkout start failures without claiming credits were added", async () => {
+    mockCreateCheckoutSession.mockReturnValue({
+      unwrap: vi.fn().mockRejectedValue({ data: { error: "stripe_unavailable" } }),
+    });
+
+    render(<BuyCredits authenticatedPrincipal={principal} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /buy \$10 credits/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Checkout could not be started/i)).toBeInTheDocument(),
+    );
+    expect(mockPostMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "openInBrowser" }),
+    );
+    expect(screen.queryByText(/Successfully added/i)).not.toBeInTheDocument();
+  });
+
+  it("lets users refresh balance after returning from checkout", async () => {
+    const onPurchaseSuccess = vi.fn();
+    mockCreateCheckoutSession.mockReturnValue({
+      unwrap: vi.fn().mockResolvedValue({ checkout_url: "https://checkout.stripe.test/session" }),
+    });
+
+    render(
+      <BuyCredits
+        authenticatedPrincipal={principal}
+        onPurchaseSuccess={onPurchaseSuccess}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /buy \$10 credits/i }));
+    await screen.findByText(/Stripe Checkout opened/i);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /I completed checkout — refresh balance/i,
+      }),
+    );
+
+    expect(onPurchaseSuccess).toHaveBeenCalledWith(10);
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "creditCheckoutEvent",
+        telemetryEvent: "valoride_credit_checkout_refresh_requested",
+      }),
+    );
+  });
+});

--- a/webview-ui/src/components/BuyCredits/index.tsx
+++ b/webview-ui/src/components/BuyCredits/index.tsx
@@ -2,7 +2,8 @@ import React, { useState } from "react";
 import { Card, Form, InputGroup, Button, Alert } from "react-bootstrap";
 import { FaCreditCard, FaShoppingCart, FaDollarSign } from "react-icons/fa";
 import CoolButton from "@valkyr/component-library/CoolButton";
-import { useRecordPaymentTransactionMutation } from "../../services/creditsApi";
+import { vscode } from "@thorapi/utils/vscode";
+import { useCreateCreditCheckoutSessionMutation } from "../../services/creditsApi";
 
 interface BuyCreditsProps {
   authenticatedPrincipal?: any;
@@ -20,12 +21,32 @@ const BuyCredits: React.FC<BuyCreditsProps> = ({
   const [amount, setAmount] = useState<number>(10);
   const [isProcessing, setIsProcessing] = useState(false);
   const [message, setMessage] = useState<{
-    type: "success" | "error";
+    type: "success" | "error" | "info";
     text: string;
   } | null>(null);
 
   // RTK Query mutations
-  const [recordPaymentTransaction] = useRecordPaymentTransactionMutation();
+  const [createCreditCheckoutSession] = useCreateCreditCheckoutSessionMutation();
+
+  const trackCheckoutEvent = (
+    state: "started" | "opened" | "failed" | "refresh_requested",
+    extra: Record<string, unknown> = {},
+  ) => {
+    vscode.postMessage({
+      type: "creditCheckoutEvent",
+      telemetryEvent: `valoride_credit_checkout_${state}`,
+      telemetryProperties: {
+        amountCents: Math.round(amount * 100),
+        creditsAmountCents: Math.round(amount * 100),
+        currency: "usd",
+        productType: "credits",
+        source: "valoride",
+        state,
+        surface: "BuyCredits",
+        ...extra,
+      },
+    });
+  };
 
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value, 10);
@@ -79,44 +100,50 @@ const BuyCredits: React.FC<BuyCreditsProps> = ({
 
     setIsProcessing(true);
     setMessage(null);
+    trackCheckoutEvent("started");
 
     try {
-      // Record payment transaction - this is the primary operation
-      // The backend handles creating the account balance, transaction history, etc.
-      const paymentTx = {
-        paidAt: new Date().toISOString(),
-        amountCents: Math.round(amount * 100),
-        credits: amount,
-      };
       const idempotencyKey =
         globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
+      const amountCents = Math.round(amount * 100);
 
-      await recordPaymentTransaction({
-        accountId: accountId as string,
-        payment: paymentTx,
+      const checkout = await createCreditCheckoutSession({
+        successUrl:
+          "https://valkyrlabs.com/checkout/success?source=valoride&product=credits&session_id={CHECKOUT_SESSION_ID}",
+        cancelUrl:
+          "https://valkyrlabs.com/buy-credits?source=valoride&status=cancelled",
+        currency: "usd",
+        amountCents,
+        creditsAmountCents: amountCents,
+        itemName: `ValorIDE $${amount} Credit Top-up`,
+        productType: "credits",
+        sku: `valoride-credits-usd-${amount}`,
         idempotencyKey,
       }).unwrap();
 
+      const checkoutUrl = checkout.checkout_url || checkout.url;
+      if (!checkoutUrl) {
+        throw new Error(checkout.error || "Checkout did not return a URL.");
+      }
+
+      vscode.postMessage({ type: "openInBrowser", url: checkoutUrl });
+      trackCheckoutEvent("opened");
+
       setMessage({
-        type: "success",
-        text: `Successfully added $${amount} credits! Your balance has been updated.`,
+        type: "info",
+        text: "Stripe Checkout opened in your browser. After payment, return here and refresh your balance while the webhook reconciles credits.",
       });
-
-      // Call success callback
-      onPurchaseSuccess?.(amount);
-
-      // Reset form
-      setAmount(10);
-
-      // Auto-dismiss success message
-      setTimeout(() => {
-        setMessage(null);
-      }, 3000);
     } catch (error: any) {
       console.error("Purchase failed:", error);
+      trackCheckoutEvent("failed", {
+        errorCode: error?.data?.error || error?.message || "checkout_failed",
+      });
       setMessage({
         type: "error",
-        text: error.data?.message || "Purchase failed. Please try again.",
+        text:
+          error.data?.message ||
+          error.message ||
+          "Checkout could not be started. No credits were booked; please try again.",
       });
     } finally {
       setIsProcessing(false);
@@ -147,12 +174,32 @@ const BuyCredits: React.FC<BuyCreditsProps> = ({
       <Card.Body>
         {message && (
           <Alert
-            variant={message.type === "success" ? "success" : "danger"}
+            variant={
+              message.type === "success"
+                ? "success"
+                : message.type === "info"
+                  ? "info"
+                  : "danger"
+            }
             className="mb-3"
             dismissible
             onClose={() => setMessage(null)}
           >
             {message.text}
+            {message.type === "info" && (
+              <div className="mt-2">
+                <Button
+                  size="sm"
+                  variant="outline-info"
+                  onClick={() => {
+                    trackCheckoutEvent("refresh_requested");
+                    onPurchaseSuccess?.(amount);
+                  }}
+                >
+                  I completed checkout — refresh balance
+                </Button>
+              </div>
+            )}
           </Alert>
         )}
 
@@ -242,7 +289,7 @@ const BuyCredits: React.FC<BuyCreditsProps> = ({
 
           <div className="mt-2 text-center">
             <small className="text-muted">
-              Secure payment via Stripe • Instant credit delivery
+              Secure Stripe Checkout • Credits post after webhook reconciliation
             </small>
           </div>
         </Form>

--- a/webview-ui/src/services/creditsApi.ts
+++ b/webview-ui/src/services/creditsApi.ts
@@ -49,6 +49,26 @@ export interface BalanceResponse {
   message?: string;
 }
 
+export interface CreateCreditCheckoutRequest {
+  successUrl: string;
+  cancelUrl: string;
+  currency?: string;
+  amountCents: number;
+  itemName?: string;
+  productType?: "credits";
+  sku?: string;
+  creditsAmountCents?: number;
+  idempotencyKey?: string;
+}
+
+export interface CreateCreditCheckoutResponse {
+  session_id?: string;
+  checkout_url?: string;
+  url?: string;
+  error?: string;
+  [key: string]: any;
+}
+
 // Error response
 export interface ErrorResponse {
   error: string;
@@ -129,6 +149,25 @@ export const creditsApi = createApi({
         { type: "Credits", id: "BALANCE" },
       ],
     }),
+
+    /**
+     * POST /v1/checkout/create-session
+     * Start a server-priced Stripe Checkout session for normal credit top-ups.
+     * This intentionally avoids the admin/test-only direct ledger booking path.
+     */
+    createCreditCheckoutSession: builder.mutation<
+      CreateCreditCheckoutResponse,
+      CreateCreditCheckoutRequest
+    >({
+      query: ({ idempotencyKey, ...body }) => ({
+        url: `checkout/create-session`,
+        method: "POST",
+        body,
+        headers: {
+          "Idempotency-Key": idempotencyKey || uuidv4(),
+        },
+      }),
+    }),
   }),
 });
 
@@ -138,6 +177,7 @@ export const {
   useLazyGetAccountBalanceQuery,
   useRecordUsageTransactionMutation,
   useRecordPaymentTransactionMutation,
+  useCreateCreditCheckoutSessionMutation,
 } = creditsApi;
 
 /**


### PR DESCRIPTION
## Summary
- replaces the in-IDE direct credit booking flow with a Stripe checkout session start
- opens checkout in the browser and shows webhook/reconciliation-aware refresh copy
- sends sanitized checkout telemetry through the extension host
- adds BuyCredits coverage for checkout start, failure, and return refresh

Refs ValkyrLabs/ValkyrAI#3065.

## Verification
- PASS: cd webview-ui && yarn test BuyCredits.test.tsx
- PASS: yarn eslint src/core/controller/index.ts src/shared/WebviewMessage.ts webview-ui/src/components/BuyCredits/index.tsx webview-ui/src/services/creditsApi.ts webview-ui/src/components/BuyCredits/BuyCredits.test.tsx
