### PR TITLE
feat(monetization): persist creator pricing saves

### DIFF
--- a/src/views/MonetizationSettings.test.tsx
+++ b/src/views/MonetizationSettings.test.tsx
@@ -1,0 +1,158 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import { JSDOM } from "jsdom";
+import type { ManagedMcpService } from "@thorapi/services/monetization/ServiceMonetizationService";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost/",
+});
+
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+(global as any).navigator = dom.window.navigator;
+(global as any).CustomEvent = dom.window.CustomEvent;
+
+jest.mock("./MonetizationSettings.css", () => ({}));
+
+jest.mock("@thorapi/services/monetization/ServiceMonetizationService", () => ({
+  enableMonetization: jest.fn(),
+  updatePricing: jest.fn(),
+}));
+
+const React = require("react");
+const { fireEvent, render, screen, waitFor } = require("@testing-library/react");
+require("@testing-library/jest-dom");
+
+const {
+  MONETIZATION_PRICING_UPDATED_EVENT,
+  MonetizationSettings,
+} = require("./MonetizationSettings");
+const { updatePricing } = require("@thorapi/services/monetization/ServiceMonetizationService");
+
+const updatePricingMock = updatePricing as jest.MockedFunction<
+  (serviceId: string, pricingModel: string, costPerCall: number) => Promise<ManagedMcpService>
+>;
+
+function monetizedService(overrides: Partial<ManagedMcpService> = {}) {
+  return {
+    id: "svc-123",
+    applicationId: "app-123",
+    name: "Revenue Bot",
+    createdBy: "creator-1",
+    status: "MONETIZED",
+    pricingModel: "PER_CALL",
+    costPerCall: 5,
+    hideFromMarketplace: false,
+    isMonetized: true,
+    createdAt: "2026-05-21T00:00:00.000Z",
+    updatedAt: "2026-05-21T00:00:00.000Z",
+    ...overrides,
+  } satisfies ManagedMcpService;
+}
+
+describe("MonetizationSettings", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("persists pricing through the backend before showing success", async () => {
+    const saved = monetizedService({ costPerCall: 8 });
+    const onSuccess = jest.fn();
+    const eventSpy = jest.fn();
+    updatePricingMock.mockResolvedValue(saved);
+    window.addEventListener(MONETIZATION_PRICING_UPDATED_EVENT, eventSpy);
+
+    render(
+      <MonetizationSettings
+        applicationId="app-123"
+        service={monetizedService()}
+        onSuccess={onSuccess}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/cost per call/i), {
+      target: { value: "8" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /update pricing/i }));
+
+    expect(updatePricingMock).toHaveBeenCalledWith("svc-123", "PER_CALL", 8);
+    expect(screen.queryByText(/pricing persisted/i)).not.toBeInTheDocument();
+
+    await screen.findByText(/pricing persisted/i);
+    expect(onSuccess).toHaveBeenCalledWith(saved);
+    expect(eventSpy).toHaveBeenCalledTimes(1);
+
+    window.removeEventListener(MONETIZATION_PRICING_UPDATED_EVENT, eventSpy);
+  });
+
+  it("does not show success when the backend rejects the pricing save", async () => {
+    const onError = jest.fn();
+    updatePricingMock.mockRejectedValue(new Error("Unauthorized"));
+
+    render(
+      <MonetizationSettings
+        applicationId="app-123"
+        service={monetizedService()}
+        onError={onError}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /update pricing/i }));
+
+    await screen.findByText("Unauthorized");
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect(screen.queryByText(/pricing persisted/i)).not.toBeInTheDocument();
+  });
+
+  it("blocks pricing saves when a monetized service has no service ID", async () => {
+    render(
+      <MonetizationSettings
+        applicationId="app-123"
+        service={monetizedService({ id: "", isMonetized: true })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /update pricing/i }));
+
+    await screen.findByText(/no service id was provided/i);
+    expect(updatePricingMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks invalid pricing before calling the backend", async () => {
+    render(
+      <MonetizationSettings applicationId="app-123" service={monetizedService()} />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/cost per call/i), {
+      target: { value: "0" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /update pricing/i }));
+
+    await screen.findByText(/at least 0.1 credits/i);
+    expect(updatePricingMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the save button disabled while pricing persistence is pending", async () => {
+    let resolveSave: (service: ManagedMcpService) => void = () => undefined;
+    updatePricingMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+
+    render(
+      <MonetizationSettings applicationId="app-123" service={monetizedService()} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /update pricing/i }));
+
+    expect(await screen.findByRole("button", { name: /updating/i })).toBeDisabled();
+
+    resolveSave(monetizedService({ costPerCall: 6 }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /update pricing/i })).toBeEnabled(),
+    );
+  });
+});

--- a/src/views/MonetizationSettings.tsx
+++ b/src/views/MonetizationSettings.tsx
@@ -7,10 +7,45 @@ import {
 } from "@thorapi/services/monetization/ServiceMonetizationService";
 import "./MonetizationSettings.css";
 
+export const MONETIZATION_PRICING_UPDATED_EVENT =
+  "valoride:monetization-pricing-updated";
+
 interface MonetizationSettingsProps {
   applicationId: string;
+  serviceId?: string;
+  service?: ManagedMcpService;
   onSuccess?: (service: ManagedMcpService) => void;
   onError?: (error: Error) => void;
+}
+
+function validatePrice(costPerCall: number): string | null {
+  if (!Number.isFinite(costPerCall) || costPerCall < 0.1) {
+    return "Enter a valid price of at least 0.1 credits before saving.";
+  }
+
+  return null;
+}
+
+function notifyPricingUpdated(service: ManagedMcpService) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent(MONETIZATION_PRICING_UPDATED_EVENT, {
+      detail: {
+        service,
+        audit: {
+          action: "creator_pricing_updated",
+          serviceId: service.id,
+          applicationId: service.applicationId,
+          pricingModel: service.pricingModel,
+          costPerCall: service.costPerCall,
+          recordedAt: new Date().toISOString(),
+        },
+      },
+    }),
+  );
 }
 
 /**
@@ -19,22 +54,60 @@ interface MonetizationSettingsProps {
  */
 export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
   applicationId,
+  serviceId,
+  service,
   onSuccess,
   onError,
 }) => {
-  const [isMonetized, setIsMonetized] = useState(false);
-  const [pricingModel, setPricingModel] = useState<PricingModel>("PER_CALL");
-  const [costPerCall, setCostPerCall] = useState(5.0);
+  const [resolvedServiceId, setResolvedServiceId] = useState(
+    service?.id ?? serviceId ?? "",
+  );
+  const [isMonetized, setIsMonetized] = useState(
+    service?.isMonetized ?? false,
+  );
+  const [pricingModel, setPricingModel] = useState<PricingModel>(
+    service?.pricingModel ?? "PER_CALL",
+  );
+  const [costPerCall, setCostPerCall] = useState(service?.costPerCall ?? 5.0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
-  // Check if this service is already monetized
   useEffect(() => {
-    // Could load existing monetization status here
-  }, [applicationId]);
+    setResolvedServiceId(service?.id ?? serviceId ?? "");
+    setIsMonetized(service?.isMonetized ?? Boolean(serviceId));
+    setPricingModel(service?.pricingModel ?? "PER_CALL");
+    setCostPerCall(service?.costPerCall ?? 5.0);
+  }, [service, serviceId, applicationId]);
+
+  const handleSaveError = (err: unknown, fallback: string) => {
+    const message = err instanceof Error ? err.message : fallback;
+    setSuccess(false);
+    setError(message);
+    onError?.(err instanceof Error ? err : new Error(message));
+  };
+
+  const completeSuccessfulSave = (result: ManagedMcpService) => {
+    setResolvedServiceId(result.id);
+    setIsMonetized(result.isMonetized ?? true);
+    setPricingModel(result.pricingModel ?? pricingModel);
+    setCostPerCall(result.costPerCall ?? costPerCall);
+    setSuccess(true);
+    onSuccess?.(result);
+    notifyPricingUpdated(result);
+
+    // Auto-hide success message after 3s
+    setTimeout(() => setSuccess(false), 3000);
+  };
 
   const handleEnableMonetization = async () => {
+    const validationError = validatePrice(costPerCall);
+    if (validationError) {
+      setError(validationError);
+      setSuccess(false);
+      return;
+    }
+
     setLoading(true);
     setError(null);
     setSuccess(false);
@@ -45,47 +118,46 @@ export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
         pricingModel,
         costPerCall,
       );
-      setIsMonetized(result.isMonetized ?? false);
-      setSuccess(true);
-
-      if (onSuccess) {
-        onSuccess(result);
-      }
-
-      // Auto-hide success message after 3s
-      setTimeout(() => setSuccess(false), 3000);
+      completeSuccessfulSave(result);
     } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Failed to enable monetization";
-      setError(message);
-
-      if (onError) {
-        onError(err instanceof Error ? err : new Error(message));
-      }
+      handleSaveError(err, "Failed to enable monetization");
     } finally {
       setLoading(false);
     }
   };
 
   const handleUpdatePricing = async () => {
+    const validationError = validatePrice(costPerCall);
+    if (validationError) {
+      setError(validationError);
+      setSuccess(false);
+      return;
+    }
+
+    if (!resolvedServiceId) {
+      setError(
+        "Select a published MCP service before updating pricing. No service ID was provided.",
+      );
+      setSuccess(false);
+      return;
+    }
+
     setLoading(true);
     setError(null);
+    setSuccess(false);
 
     try {
-      // First get the service to get its ID
-      // In real implementation, you'd pass serviceId as prop
-      // await updatePricing(serviceId, pricingModel, costPerCall);
-      // For now, just show success
-      setSuccess(true);
-      setTimeout(() => setSuccess(false), 3000);
+      const result = await updatePricing(
+        resolvedServiceId,
+        pricingModel,
+        costPerCall,
+      );
+      completeSuccessfulSave(result);
     } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Failed to update pricing";
-      setError(message);
-
-      if (onError) {
-        onError(err instanceof Error ? err : new Error(message));
-      }
+      handleSaveError(
+        err,
+        "Pricing was not saved. Check your permissions and try again.",
+      );
     } finally {
       setLoading(false);
     }
@@ -102,7 +174,9 @@ export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
 
       {error && <div className="error-banner">{error}</div>}
       {success && (
-        <div className="success-banner">✓ Settings saved successfully!</div>
+        <div className="success-banner">
+          ✓ Pricing persisted. Marketplace and earnings views can refresh now.
+        </div>
       )}
 
       <div className="settings-form">
@@ -110,26 +184,28 @@ export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
         <div className="form-group">
           <label>Pricing Model</label>
           <div className="radio-group">
-            {["PER_CALL", "PER_MONTH", "TIERED"].map((model) => (
-              <label key={model} className="radio-label">
-                <input
-                  type="radio"
-                  value={model}
-                  checked={pricingModel === model}
-                  onChange={(e) =>
-                    setPricingModel(e.target.value as PricingModel)
-                  }
-                  disabled={loading}
-                />
-                <span>
-                  {model === "PER_CALL"
-                    ? "Per Call"
-                    : model === "PER_MONTH"
-                      ? "Monthly Subscription"
-                      : "Tiered"}
-                </span>
-              </label>
-            ))}
+            {(["PER_CALL", "PER_MONTH", "TIERED"] as PricingModel[]).map(
+              (model) => (
+                <label key={model} className="radio-label">
+                  <input
+                    type="radio"
+                    value={model}
+                    checked={pricingModel === model}
+                    onChange={(e) =>
+                      setPricingModel(e.target.value as PricingModel)
+                    }
+                    disabled={loading}
+                  />
+                  <span>
+                    {model === "PER_CALL"
+                      ? "Per Call"
+                      : model === "PER_MONTH"
+                        ? "Monthly Subscription"
+                        : "Tiered"}
+                  </span>
+                </label>
+              ),
+            )}
           </div>
         </div>
 
@@ -178,6 +254,16 @@ export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
           </p>
         </div>
 
+        {isMonetized && (
+          <div className="revenue-breakdown">
+            <h4>Next best actions</h4>
+            <p className="breakdown-note">
+              Publish paid service, preview buyer card, then share listing once
+              the saved price appears in marketplace refreshes.
+            </p>
+          </div>
+        )}
+
         {/* Action Buttons */}
         <div className="button-group">
           {!isMonetized ? (
@@ -206,7 +292,7 @@ export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
 
         {/* Terms & Conditions */}
         <div className="terms-notice">
-          <input type="checkbox" id="agreeTerms" />
+          <input type="checkbox" id="agreeTerms" disabled={loading} />
           <label htmlFor="agreeTerms">
             I agree to the Monetization Terms & Service
           </label>


### PR DESCRIPTION
## Summary\n- wire MonetizationSettings to call the real pricing persistence endpoint with a concrete service ID\n- add validation, loading/disabled states, actionable missing-service and unauthorized error handling\n- dispatch a pricing-updated event with audit details so marketplace/earnings surfaces can refresh after saves\n\n## Tests\n- ./node_modules/.bin/eslint src/views/MonetizationSettings.tsx src/views/MonetizationSettings.test.tsx\n- ./node_modules/.bin/jest src/views/MonetizationSettings.test.tsx --runInBand --forceExit\n- npm run check-types -- --pretty false *(blocked by pre-existing rc-5 syntax/conflict issues in RemoteCodingSessionRegistry.ts and ExtensionMessage.tsx)*\n\nRefs ValkyrLabs/ValkyrAI#2804