### PR TITLE
fix(auth): require code exchange for ValorIDE callback

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,13 @@ import { initializeTestMode, cleanupTestMode } from "./services/test/TestMode";
 import { registerUrlCommands } from "./commands/urlCommands";
 import { registerAliasCommands } from "./commands/aliasCommands";
 import { StartupAuthService } from "./services/auth/StartupAuthService";
+import { ValorideAuthCodeExchangeService } from "./services/auth/ValorideAuthCodeExchangeService";
+import {
+  hasDirectCallbackCredentials,
+  parseAuthCallbackQuery,
+  parseLegacyAuthCallbackCredentials,
+  summarizeAuthCallback,
+} from "./security/authCallback";
 import { initializePromptService } from "./services/promptService";
 import { initializeMemoryBankLoader } from "./services/memoryBankLoader";
 import { initializeLLMContextInjector } from "./services/llmContextInjector";
@@ -84,15 +91,15 @@ export function activate(context: vscode.ExtensionContext) {
       const { selectedLlmDetails } = await getAllExtensionState(context);
       const manualSelection: SelectedPrompt | undefined = selectedLlmDetails
         ? {
-          llmDetailsId: selectedLlmDetails.id,
-          name: selectedLlmDetails.name,
-          prompt: selectedLlmDetails.prompt,
-          mode: selectedLlmDetails.mode,
-          tags: selectedLlmDetails.tags,
-          source:
-            selectedLlmDetails.source === "fallback" ? "fallback" : "thorapi",
-          stackSpecific: true,
-        }
+            llmDetailsId: selectedLlmDetails.id,
+            name: selectedLlmDetails.name,
+            prompt: selectedLlmDetails.prompt,
+            mode: selectedLlmDetails.mode,
+            tags: selectedLlmDetails.tags,
+            source:
+              selectedLlmDetails.source === "fallback" ? "fallback" : "thorapi",
+            stackSpecific: true,
+          }
         : undefined;
 
       await initializeLLMPromptService(
@@ -227,9 +234,8 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Initialize ToolRelayService for remote control capabilities
     try {
-      const toolRelayMod = await import(
-        "./services/communication/ToolRelayService"
-      );
+      const toolRelayMod =
+        await import("./services/communication/ToolRelayService");
       const visibleWebview =
         WebviewProvider.getVisibleInstance() || sidebarWebview;
       if (visibleWebview?.controller) {
@@ -516,7 +522,8 @@ export function activate(context: vscode.ExtensionContext) {
   https://code.visualstudio.com/api/extension-guides/virtual-documents
   */
   const diffContentProvider = new (class
-    implements vscode.TextDocumentContentProvider {
+    implements vscode.TextDocumentContentProvider
+  {
     provideTextDocumentContent(uri: vscode.Uri): string {
       return Buffer.from(uri.query, "base64").toString("utf-8");
     }
@@ -530,17 +537,16 @@ export function activate(context: vscode.ExtensionContext) {
 
   // URI Handler
   const handleUri = async (uri: vscode.Uri) => {
-    console.log("URI Handler called with:", {
-      path: uri.path,
-      query: uri.query,
-      scheme: uri.scheme,
-    });
-
     const path = uri.path;
-    // Guard against missing query to avoid calling replace on undefined
-    const rawQuery = uri.query || "";
-    const query = new URLSearchParams(rawQuery.replace(/\+/g, "%2B"));
+    const query = parseAuthCallbackQuery(uri.query);
     const visibleWebview = WebviewProvider.getVisibleInstance();
+
+    Logger.log(
+      `URI Handler called with: ${JSON.stringify(
+        summarizeAuthCallback(query, uri.path, uri.scheme),
+      )}`,
+    );
+
     if (!visibleWebview) {
       return;
     }
@@ -553,46 +559,69 @@ export function activate(context: vscode.ExtensionContext) {
         break;
       }
       case "/auth": {
-        const token = query.get("token");
         const state = query.get("state");
-        const apiKey = query.get("apiKey");
-        const authenticatedPrincipal = query.get("authenticatedPrincipal");
 
-        console.log("Auth callback received:", {
-          token: token,
-          state: state,
-          apiKey: apiKey,
-          authenticatedPrincipal: authenticatedPrincipal,
-        });
-
-        // Validate state parameter
+        // Validate state before reading any credential-bearing field.
         if (!(await visibleWebview?.controller.validateAuthState(state))) {
           vscode.window.showErrorMessage("Invalid auth state");
           return;
         }
 
-        if (token && apiKey) {
-          let parsedUser;
-          try {
-            parsedUser = authenticatedPrincipal
-              ? JSON.parse(decodeURIComponent(authenticatedPrincipal))
-              : undefined;
-          } catch (error) {
-            console.warn("Failed to parse authenticatedPrincipal:", error);
+        const startupAuthService = StartupAuthService.getInstance(context);
+        const code = query.get("code");
+        if (code && state) {
+          const exchange =
+            await new ValorideAuthCodeExchangeService().exchangeCode(
+              code,
+              state,
+            );
+          await startupAuthService.handleSuccessfulLogin(
+            exchange.tokens,
+            exchange.user,
+          );
+
+          if (exchange.tokens.apiKey) {
+            await visibleWebview?.controller.handleAuthCallback(
+              exchange.tokens.jwtToken,
+              exchange.tokens.apiKey,
+              exchange.user,
+            );
+          }
+          break;
+        }
+
+        if (hasDirectCallbackCredentials(query)) {
+          const isProductionExtension =
+            context.extensionMode === vscode.ExtensionMode.Production ||
+            process.env.NODE_ENV === "production";
+          if (isProductionExtension) {
+            Logger.log(
+              `Rejected direct credential auth callback: ${JSON.stringify(
+                summarizeAuthCallback(query, uri.path, uri.scheme),
+              )}`,
+            );
+            vscode.window.showErrorMessage(
+              "ValorIDE sign-in must use a one-time authorization code. Please retry sign-in.",
+            );
+            return;
           }
 
-          // Use StartupAuthService to handle login persistently
-          const startupAuthService = StartupAuthService.getInstance(context);
-          await startupAuthService.handleSuccessfulLogin(
-            { jwtToken: token, apiKey },
-            parsedUser,
-          );
+          const legacyCredentials = parseLegacyAuthCallbackCredentials(query);
+          if (legacyCredentials) {
+            await startupAuthService.handleSuccessfulLogin(
+              {
+                jwtToken: legacyCredentials.token,
+                apiKey: legacyCredentials.apiKey,
+              },
+              legacyCredentials.authenticatedPrincipal,
+            );
 
-          await visibleWebview?.controller.handleAuthCallback(
-            token,
-            apiKey,
-            parsedUser,
-          );
+            await visibleWebview?.controller.handleAuthCallback(
+              legacyCredentials.token,
+              legacyCredentials.apiKey,
+              legacyCredentials.authenticatedPrincipal,
+            );
+          }
         }
         break;
       }
@@ -908,7 +937,6 @@ export function deactivate() {
       Logger.log(`Error cleaning up test mode: ${error}`);
       console.error("Error cleaning up test mode:", error);
     }
-
 
     Logger.log("ValorIDE extension deactivated successfully");
     resolve();

--- a/src/security/authCallback.test.ts
+++ b/src/security/authCallback.test.ts
@@ -1,0 +1,68 @@
+import {
+  hasDirectCallbackCredentials,
+  parseAuthCallbackQuery,
+  parseLegacyAuthCallbackCredentials,
+  redactAuthCallbackLogPayload,
+  summarizeAuthCallback,
+} from "./authCallback";
+
+describe("auth callback security helpers", () => {
+  it("summarizes callback query state without exposing credential values", () => {
+    const params = parseAuthCallbackQuery(
+      "state=nonce&token=jwt.secret.value&apiKey=sk_live_secret&authenticatedPrincipal=%7B%22email%22%3A%22a%40b.com%22%7D",
+    );
+
+    const summary = summarizeAuthCallback(params, "/auth", "valoride");
+
+    expect(summary).toMatchObject({
+      path: "/auth",
+      scheme: "valoride",
+      hasState: true,
+      hasDirectCredential: true,
+      hasApiCredential: true,
+      hasPrincipalPayload: true,
+    });
+    expect(JSON.stringify(summary)).not.toContain("jwt.secret.value");
+    expect(JSON.stringify(summary)).not.toContain("sk_live_secret");
+    expect(JSON.stringify(summary)).not.toContain("a@b.com");
+    expect(JSON.stringify(summary)).not.toMatch(
+      /token|apiKey|jwt|Authorization|authenticatedPrincipal/i,
+    );
+  });
+
+  it("detects direct token delivery so production callbacks can reject it", () => {
+    expect(
+      hasDirectCallbackCredentials(
+        parseAuthCallbackQuery("state=nonce&code=one-time-code"),
+      ),
+    ).toBe(false);
+    expect(
+      hasDirectCallbackCredentials(
+        parseAuthCallbackQuery("state=nonce&token=jwt&apiKey=key"),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps legacy parsing isolated from log payloads", () => {
+    const params = parseAuthCallbackQuery(
+      "state=nonce&token=jwt.secret.value&apiKey=sk_live_secret&authenticatedPrincipal=%7B%22id%22%3A%22u1%22%7D",
+    );
+
+    expect(parseLegacyAuthCallbackCredentials(params)).toEqual({
+      token: "jwt.secret.value",
+      apiKey: "sk_live_secret",
+      authenticatedPrincipal: { id: "u1" },
+    });
+    expect(
+      redactAuthCallbackLogPayload({
+        token: "jwt",
+        apiKey: "key",
+        state: "nonce",
+      }),
+    ).toEqual({
+      token: "[redacted]",
+      apiKey: "[redacted]",
+      state: "nonce",
+    });
+  });
+});

--- a/src/security/authCallback.ts
+++ b/src/security/authCallback.ts
@@ -1,0 +1,99 @@
+export const SENSITIVE_AUTH_CALLBACK_PARAMS = [
+  "token",
+  "apiKey",
+  "jwt",
+  "authorization",
+  "authenticatedPrincipal",
+] as const;
+
+const SENSITIVE_PARAM_SET = new Set<string>(
+  SENSITIVE_AUTH_CALLBACK_PARAMS.map((param) => param.toLowerCase()),
+);
+
+export interface AuthCallbackSummary {
+  path: string;
+  scheme: string;
+  hasQuery: boolean;
+  hasState: boolean;
+  hasCode: boolean;
+  hasDirectCredential: boolean;
+  hasApiCredential: boolean;
+  hasPrincipalPayload: boolean;
+  queryParamNames: string[];
+}
+
+export interface LegacyAuthCallbackCredentials {
+  token: string;
+  apiKey: string;
+  authenticatedPrincipal?: unknown;
+}
+
+export const parseAuthCallbackQuery = (
+  rawQuery: string | undefined,
+): URLSearchParams =>
+  new URLSearchParams((rawQuery || "").replace(/\+/g, "%2B"));
+
+export const summarizeAuthCallback = (
+  params: URLSearchParams,
+  path = "",
+  scheme = "",
+): AuthCallbackSummary => {
+  const queryParamNames = Array.from(new Set(Array.from(params.keys()))).map(
+    (name) =>
+      SENSITIVE_PARAM_SET.has(name.toLowerCase()) ? "sensitive:redacted" : name,
+  );
+
+  return {
+    path,
+    scheme,
+    hasQuery: Array.from(params.keys()).length > 0,
+    hasState: params.has("state"),
+    hasCode: params.has("code"),
+    hasDirectCredential: params.has("token") || params.has("jwt"),
+    hasApiCredential: params.has("apiKey"),
+    hasPrincipalPayload: params.has("authenticatedPrincipal"),
+    queryParamNames,
+  };
+};
+
+export const hasDirectCallbackCredentials = (
+  params: URLSearchParams,
+): boolean =>
+  params.has("token") ||
+  params.has("apiKey") ||
+  params.has("jwt") ||
+  params.has("authenticatedPrincipal");
+
+export const parseLegacyAuthCallbackCredentials = (
+  params: URLSearchParams,
+): LegacyAuthCallbackCredentials | null => {
+  const token = params.get("token") || params.get("jwt");
+  const apiKey = params.get("apiKey");
+
+  if (!token || !apiKey) {
+    return null;
+  }
+
+  const rawPrincipal = params.get("authenticatedPrincipal");
+  let authenticatedPrincipal: unknown;
+  if (rawPrincipal) {
+    try {
+      authenticatedPrincipal = JSON.parse(decodeURIComponent(rawPrincipal));
+    } catch {
+      authenticatedPrincipal = undefined;
+    }
+  }
+
+  return { token, apiKey, authenticatedPrincipal };
+};
+
+export const redactAuthCallbackLogPayload = (
+  payload: Record<string, unknown>,
+): Record<string, unknown> => {
+  return Object.fromEntries(
+    Object.entries(payload).map(([key, value]) => [
+      key,
+      SENSITIVE_PARAM_SET.has(key.toLowerCase()) ? "[redacted]" : value,
+    ]),
+  );
+};

--- a/src/services/auth/ValorideAuthCodeExchangeService.ts
+++ b/src/services/auth/ValorideAuthCodeExchangeService.ts
@@ -1,0 +1,39 @@
+import axios from "axios";
+import { getValkyraiBasePath } from "@utils/serverValkyraiHost";
+import { AuthenticatedUser, AuthTokens } from "./TokenStorageService";
+
+export interface AuthCodeExchangeResult {
+  tokens: AuthTokens;
+  user?: AuthenticatedUser;
+}
+
+export class ValorideAuthCodeExchangeService {
+  async exchangeCode(
+    code: string,
+    state: string,
+  ): Promise<AuthCodeExchangeResult> {
+    const baseUrl = getValkyraiBasePath();
+    const response = await axios.post(
+      `${baseUrl}/auth/valoride/code-exchange`,
+      { code, state },
+      { timeout: 10000 },
+    );
+
+    const token = response.data?.token || response.data?.jwtToken;
+    if (!token) {
+      throw new Error(
+        "ValorIDE auth code exchange response did not include a JWT token",
+      );
+    }
+
+    return {
+      tokens: {
+        jwtToken: token,
+        apiKey: response.data?.apiKey,
+        refreshToken: response.data?.refreshToken,
+        expiresAt: response.data?.expiresAt,
+      },
+      user: response.data?.user || response.data?.authenticatedPrincipal,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- replace raw URI callback query logging with redacted auth callback summaries
- validate state before reading credential-bearing callback fields
- add one-time code exchange path and reject direct token/API-key query delivery in production
- add auth callback helper coverage to guard against leaked token/apiKey/jwt/Authorization payloads

## Validation
- PASS: npx eslint src/extension.ts src/security/authCallback.ts src/security/authCallback.test.ts src/services/auth/ValorideAuthCodeExchangeService.ts
- KNOWN BASELINE FAIL: yarn run compile-tests currently fails on existing suite config issues (missing jest/expect globals and webview-ui rootDir TS6059 errors), unrelated to this patch.

Related: https://github.com/ValkyrLabs/ValkyrAI/issues/3092