### PR TITLE
feat(agentic): add capability recovery command center

### DIFF
--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import CapabilityCommandCenter, {
+  getRecoveryActions,
+  type AgenticCapability,
+} from "./CapabilityCommandCenter";
+import * as vscodeModule from "../../utils/vscode";
+
+vi.mock("../../utils/vscode", () => ({
+  vscode: { postMessage: vi.fn() },
+}));
+
+const degradedCapabilities: AgenticCapability[] = [
+  {
+    id: "memory",
+    label: "GrayMatter",
+    status: "unauthenticated",
+    workspaceId: "ws_123",
+  },
+  { id: "credits", label: "Credits", status: "quota", projectId: "proj_456" },
+  { id: "rbac", label: "Team access", status: "forbidden" },
+  { id: "mcp", label: "MCP", status: "mcp_disconnected" },
+  { id: "swarm", label: "SWARM", status: "swarm_error" },
+  { id: "api", label: "ValkyrAI API", status: "unavailable" },
+];
+
+describe("CapabilityCommandCenter", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders at least one recovery action for every degraded status", () => {
+    for (const capability of degradedCapabilities) {
+      expect(getRecoveryActions(capability)).not.toHaveLength(0);
+    }
+  });
+
+  it.each([
+    ["unauthenticated", "Sign in", { type: "accountLoginClicked" }],
+    ["quota", "Buy credits", { type: "openInBrowser", url: "/buy-credits" }],
+    [
+      "forbidden",
+      "Request access",
+      { type: "openInBrowser", url: "/valoride/access-request" },
+    ],
+    ["mcp_disconnected", "Retry MCP", { type: "fetchLatestMcpServersFromHub" }],
+    [
+      "swarm_error",
+      "Run diagnostics",
+      { type: "displayVSCodeInfo", text: "Run ValorIDE diagnostics" },
+    ],
+    [
+      "unavailable",
+      "Run diagnostics",
+      { type: "displayVSCodeInfo", text: "Run ValorIDE diagnostics" },
+    ],
+  ] as const)(
+    "dispatches primary recovery for %s capabilities",
+    (_status, label, expectedMessage) => {
+      const capability = degradedCapabilities.find(
+        (candidate) => candidate.status === _status,
+      );
+      expect(capability).toBeDefined();
+      render(
+        <CapabilityCommandCenter
+          capabilities={[capability!]}
+          returnTo="valoride://task/abc"
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: label }));
+      expect(vscodeModule.vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining(
+          Object.fromEntries(
+            Object.entries(expectedMessage).map(([key, value]) => [
+              key,
+              key === "url" || key === "text"
+                ? expect.stringContaining(value)
+                : value,
+            ]),
+          ),
+        ),
+      );
+    },
+  );
+
+  it("routes quota failures to buy credits with ValorIDE context", () => {
+    render(
+      <CapabilityCommandCenter
+        capabilities={[degradedCapabilities[1]]}
+        returnTo="valoride://task/abc"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Buy credits" }));
+    expect(vscodeModule.vscode.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining("projectId=proj_456"),
+      }),
+    );
+    expect(vscodeModule.vscode.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining("source=valoride"),
+      }),
+    );
+  });
+
+  it("renders compact CTAs for MCP, SWARM, RBAC, and unavailable states", () => {
+    render(
+      <CapabilityCommandCenter capabilities={degradedCapabilities.slice(2)} />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Request access" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Retry MCP" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", { name: "Run diagnostics" }),
+    ).toHaveLength(2);
+  });
+});

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
@@ -1,0 +1,238 @@
+import React from "react";
+import type { WebviewMessage } from "@shared/WebviewMessage";
+import { vscode } from "../../utils/vscode";
+
+export type CapabilityStatus =
+  | "ready"
+  | "unauthenticated"
+  | "quota"
+  | "forbidden"
+  | "unavailable"
+  | "mcp_disconnected"
+  | "swarm_error";
+
+export interface AgenticCapability {
+  id: string;
+  label: string;
+  status: CapabilityStatus;
+  detail?: string;
+  workspaceId?: string;
+  projectId?: string;
+}
+
+interface RecoveryAction {
+  label: string;
+  message: Pick<WebviewMessage, "type" | "url" | "text">;
+  kind: "primary" | "secondary";
+}
+
+interface CapabilityCommandCenterProps {
+  capabilities: AgenticCapability[];
+  returnTo?: string;
+}
+
+const VALKYR_BASE = "https://valkyrlabs.com";
+
+const withContext = (
+  path: string,
+  capability: AgenticCapability,
+  returnTo = "valoride://capability-recovery",
+) => {
+  const url = new URL(path, VALKYR_BASE);
+  url.searchParams.set("source", "valoride");
+  url.searchParams.set("capability", capability.id);
+  url.searchParams.set("returnTo", returnTo);
+  if (capability.workspaceId)
+    url.searchParams.set("workspaceId", capability.workspaceId);
+  if (capability.projectId)
+    url.searchParams.set("projectId", capability.projectId);
+  return url.toString();
+};
+
+export const getRecoveryActions = (
+  capability: AgenticCapability,
+  returnTo?: string,
+): RecoveryAction[] => {
+  switch (capability.status) {
+    case "unauthenticated":
+      return [
+        {
+          label: "Sign in",
+          kind: "primary",
+          message: { type: "accountLoginClicked" },
+        },
+        {
+          label: "Activate workspace",
+          kind: "secondary",
+          message: {
+            type: "openInBrowser",
+            url: withContext("/valoride/activate", capability, returnTo),
+          },
+        },
+      ];
+    case "quota":
+      return [
+        {
+          label: "Buy credits",
+          kind: "primary",
+          message: {
+            type: "openInBrowser",
+            url: withContext("/buy-credits", capability, returnTo),
+          },
+        },
+        {
+          label: "Retry after purchase",
+          kind: "secondary",
+          message: {
+            type: "displayVSCodeInfo",
+            text: "Retry the blocked ValorIDE capability after checkout returns.",
+          },
+        },
+      ];
+    case "forbidden":
+      return [
+        {
+          label: "Request access",
+          kind: "primary",
+          message: {
+            type: "openInBrowser",
+            url: withContext("/valoride/access-request", capability, returnTo),
+          },
+        },
+        {
+          label: "Admin guide",
+          kind: "secondary",
+          message: {
+            type: "openInBrowser",
+            url: withContext(
+              "/v1/docs/Products/ValorIDE/team-access",
+              capability,
+              returnTo,
+            ),
+          },
+        },
+      ];
+    case "mcp_disconnected":
+      return [
+        {
+          label: "Retry MCP",
+          kind: "primary",
+          message: { type: "fetchLatestMcpServersFromHub" },
+        },
+        {
+          label: "Setup guide",
+          kind: "secondary",
+          message: {
+            type: "openInBrowser",
+            url: withContext(
+              "/v1/docs/Products/ValorIDE/mcp-setup",
+              capability,
+              returnTo,
+            ),
+          },
+        },
+      ];
+    case "swarm_error":
+    case "unavailable":
+      return [
+        {
+          label: "Run diagnostics",
+          kind: "primary",
+          message: {
+            type: "displayVSCodeInfo",
+            text: `Run ValorIDE diagnostics for ${capability.label}.`,
+          },
+        },
+        {
+          label: "Recovery guide",
+          kind: "secondary",
+          message: {
+            type: "openInBrowser",
+            url: withContext(
+              "/v1/docs/Products/ValorIDE/recovery",
+              capability,
+              returnTo,
+            ),
+          },
+        },
+      ];
+    case "ready":
+    default:
+      return [];
+  }
+};
+
+const statusCopy: Record<CapabilityStatus, string> = {
+  ready: "Ready",
+  unauthenticated: "Sign-in needed",
+  quota: "Quota blocked",
+  forbidden: "Access blocked",
+  unavailable: "Unavailable",
+  mcp_disconnected: "MCP disconnected",
+  swarm_error: "SWARM needs attention",
+};
+
+export const CapabilityCommandCenter: React.FC<
+  CapabilityCommandCenterProps
+> = ({ capabilities, returnTo }) => {
+  const handleAction = (
+    capability: AgenticCapability,
+    action: RecoveryAction,
+  ) => {
+    vscode.postMessage({
+      type: "displayVSCodeInfo",
+      text: `valoride_capability_recovery_clicked:${capability.id}:${action.label}`,
+    });
+    vscode.postMessage(action.message);
+  };
+
+  return (
+    <section
+      aria-label="Agentic capability command center"
+      style={{ display: "grid", gap: 8 }}
+    >
+      {capabilities.map((capability) => {
+        const actions = getRecoveryActions(capability, returnTo);
+        return (
+          <article
+            key={capability.id}
+            style={{
+              border: "1px solid var(--vscode-panel-border)",
+              borderRadius: 8,
+              padding: 10,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                gap: 8,
+              }}
+            >
+              <strong>{capability.label}</strong>
+              <span>{statusCopy[capability.status]}</span>
+            </div>
+            {capability.detail && (
+              <p style={{ margin: "6px 0" }}>{capability.detail}</p>
+            )}
+            {actions.length > 0 && (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                {actions.map((action) => (
+                  <button
+                    key={action.label}
+                    type="button"
+                    onClick={() => handleAction(capability, action)}
+                  >
+                    {action.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </article>
+        );
+      })}
+    </section>
+  );
+};
+
+export default CapabilityCommandCenter;


### PR DESCRIPTION
## Summary
- Adds a reusable ValorIDE agentic capability command center for degraded capability states
- Provides actionable recovery CTAs for unauthenticated, quota, forbidden, MCP disconnected, SWARM error, and unavailable states
- Routes credit upsell and activation/access docs through contextual ValorIDE URLs

## Tests
- npm test -- CapabilityCommandCenter.test.tsx
- npm run build (fails: existing missing @reduxjs/toolkit/query/react, redux-query, react-redux declarations in generated thorapi services)

Closes https://github.com/ValkyrLabs/ValkyrAI/issues/3035