### PR TITLE
fix(swarm): use configured ValkyrAI host for discovery

### DIFF
--- a/webview-ui/src/api/hooks/useDiscoveryQuery.test.tsx
+++ b/webview-ui/src/api/hooks/useDiscoveryQuery.test.tsx
@@ -1,0 +1,161 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildSwarmDiscoveryUrl,
+  classifySwarmDiscoveryStatus,
+  getSwarmDiscoveryHeaders,
+  getSwarmDiscoveryRecoveryActions,
+  getSwarmDiscoveryEndpointType,
+  useDiscoveryQuery,
+} from "./useDiscoveryQuery";
+import { setValkyraiHost } from "../../utils/valkyraiHost";
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+
+describe("useDiscoveryQuery host-aware Swarm discovery", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => Promise.resolve(jsonResponse([]))),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+    setValkyraiHost("https://api-0.valkyrlabs.com/v1");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  it("builds hosted and enterprise discovery URLs from the configured ValkyrAI API host", () => {
+    expect(
+      buildSwarmDiscoveryUrl({
+        organizationId: "org-1",
+        status: "ONLINE",
+        apiHost: "https://api-0.valkyrlabs.com/v1",
+      }),
+    ).toBe(
+      "https://api-0.valkyrlabs.com/v1/swarm/agents?organizationId=org-1&status=ONLINE",
+    );
+
+    expect(
+      buildSwarmDiscoveryUrl({
+        organizationId: "org-2",
+        apiHost: "https://enterprise.example.com",
+        path: "agents/discovery",
+      }),
+    ).toBe(
+      "https://enterprise.example.com/v1/swarm/agents/discovery?organizationId=org-2",
+    );
+  });
+
+  it("uses localhost only when an explicit local fallback is requested", () => {
+    expect(
+      buildSwarmDiscoveryUrl({
+        organizationId: "org-local",
+        apiHost: undefined,
+        allowLocalFallback: true,
+      }),
+    ).toBe("http://localhost:8080/v1/swarm/agents?organizationId=org-local");
+  });
+
+  it("attaches the stored ValorIDE auth token to discovery requests", () => {
+    window.sessionStorage.setItem("jwtToken", "session-token");
+
+    expect(getSwarmDiscoveryHeaders().get("Authorization")).toBe(
+      "Bearer session-token",
+    );
+  });
+
+  it("classifies auth, RBAC, cloud, local, and empty recovery states", () => {
+    expect(classifySwarmDiscoveryStatus(401, "hosted")).toBe("auth_needed");
+    expect(classifySwarmDiscoveryStatus(403, "enterprise")).toBe("rbac_denied");
+    expect(classifySwarmDiscoveryStatus(503, "hosted")).toBe(
+      "cloud_unavailable",
+    );
+    expect(classifySwarmDiscoveryStatus(503, "local")).toBe(
+      "local_unavailable",
+    );
+    expect(getSwarmDiscoveryRecoveryActions("empty")).toContainEqual({
+      id: "swarm-setup",
+      label: "Register first Swarm agent",
+    });
+  });
+
+  it("refreshes discovery when the configured ValkyrAI host changes", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(jsonResponse([{ id: "agent-1" }])),
+    );
+
+    const { result } = renderHook(() =>
+      useDiscoveryQuery({ organizationId: "org-1" }),
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://api-0.valkyrlabs.com/v1/swarm/agents?organizationId=org-1",
+    );
+    expect(result.current.endpointType).toBe("hosted");
+
+    act(() => {
+      setValkyraiHost("https://enterprise.example.com/v1");
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      "https://enterprise.example.com/v1/swarm/agents?organizationId=org-1",
+    );
+    expect(result.current.endpointType).toBe("enterprise");
+  });
+
+  it("surfaces actionable auth and empty-agent states", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        { message: "login required" },
+        { status: 401, statusText: "Unauthorized" },
+      ),
+    );
+
+    const { result, rerender } = renderHook(() =>
+      useDiscoveryQuery({ organizationId: "org-1" }),
+    );
+
+    await waitFor(() => expect(result.current.errorKind).toBe("auth_needed"));
+    expect(result.current.recoveryActions).toContainEqual({
+      id: "connect-account",
+      label: "Connect ValkyrAI account",
+    });
+
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+    await act(async () => {
+      await result.current.refetch();
+    });
+    rerender();
+
+    await waitFor(() => expect(result.current.errorKind).toBe("empty"));
+    expect(result.current.recoveryActions).toContainEqual({
+      id: "swarm-setup",
+      label: "Register first Swarm agent",
+    });
+  });
+
+  it("does not regress hosted/local endpoint type detection", () => {
+    expect(
+      getSwarmDiscoveryEndpointType("https://api-0.valkyrlabs.com/v1"),
+    ).toBe("hosted");
+    expect(getSwarmDiscoveryEndpointType("http://localhost:8080/v1")).toBe(
+      "local",
+    );
+  });
+});

--- a/webview-ui/src/api/hooks/useDiscoveryQuery.ts
+++ b/webview-ui/src/api/hooks/useDiscoveryQuery.ts
@@ -1,6 +1,19 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  getValkyraiHost,
+  subscribeToValkyraiHost,
+} from "../../utils/valkyraiHost";
 
-const SWARM_API_BASE = "http://localhost:8080/v1/swarm";
+const LOCAL_SWARM_API_BASE = "http://localhost:8080/v1/swarm";
+
+export type SwarmDiscoveryEndpointType = "hosted" | "enterprise" | "local";
+export type SwarmDiscoveryErrorKind =
+  | "auth_needed"
+  | "rbac_denied"
+  | "cloud_unavailable"
+  | "local_unavailable"
+  | "empty"
+  | "unknown";
 
 export interface AgentDiscoveryRecord {
   id: string;
@@ -21,13 +34,158 @@ export interface UseDiscoveryQueryOptions {
   refetchInterval?: number;
 }
 
+export interface SwarmDiscoveryRecoveryAction {
+  id: "connect-account" | "swarm-setup" | "buy-credits" | "retry";
+  label: string;
+}
+
 export interface UseDiscoveryQueryResult {
   data: AgentDiscoveryRecord[];
   isLoading: boolean;
   isError: boolean;
   error: Error | null;
+  errorKind: SwarmDiscoveryErrorKind | null;
+  endpoint: string;
+  endpointType: SwarmDiscoveryEndpointType;
+  recoveryActions: SwarmDiscoveryRecoveryAction[];
   refetch: () => Promise<void>;
 }
+
+interface BuildDiscoveryUrlOptions {
+  organizationId: string;
+  status?: string;
+  apiHost?: string | null;
+  path?: "agents" | "agents/discovery";
+  allowLocalFallback?: boolean;
+}
+
+const trimTrailingSlashes = (value: string) => value.replace(/\/+$/, "");
+
+const normalizeApiHost = (host?: string | null) => {
+  const candidate = (host || "").trim();
+  if (!candidate) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(candidate);
+    const pathname = parsed.pathname.replace(/\/+$/, "");
+    parsed.pathname = pathname && pathname !== "/" ? pathname : "/v1";
+    return trimTrailingSlashes(
+      `${parsed.protocol}//${parsed.host}${parsed.pathname}`,
+    );
+  } catch {
+    return undefined;
+  }
+};
+
+export const getSwarmDiscoveryEndpointType = (
+  apiHost?: string | null,
+): SwarmDiscoveryEndpointType => {
+  const normalized = normalizeApiHost(apiHost);
+  if (
+    !normalized ||
+    /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?\b/i.test(normalized)
+  ) {
+    return "local";
+  }
+  if (/\.valkyrlabs\.com\b/i.test(new URL(normalized).host)) {
+    return "hosted";
+  }
+  return "enterprise";
+};
+
+export const buildSwarmDiscoveryUrl = ({
+  organizationId,
+  status,
+  apiHost,
+  path = "agents",
+  allowLocalFallback = false,
+}: BuildDiscoveryUrlOptions) => {
+  const normalizedHost = normalizeApiHost(apiHost);
+  const base = normalizedHost
+    ? `${normalizedHost}/swarm`
+    : allowLocalFallback
+      ? LOCAL_SWARM_API_BASE
+      : `${normalizeApiHost(getValkyraiHost())}/swarm`;
+  const url = new URL(`${base}/${path}`);
+  url.searchParams.set("organizationId", organizationId);
+
+  if (status && status !== "all") {
+    url.searchParams.set("status", status);
+  }
+
+  return url.toString();
+};
+
+const readAuthToken = () => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return (
+    window.sessionStorage.getItem("jwtToken") ||
+    window.sessionStorage.getItem("jwtSession") ||
+    window.localStorage.getItem("jwtToken") ||
+    window.localStorage.getItem("authToken")
+  );
+};
+
+export const getSwarmDiscoveryHeaders = () => {
+  const headers = new Headers({ Accept: "application/json" });
+  const token = readAuthToken();
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  return headers;
+};
+
+export const classifySwarmDiscoveryStatus = (
+  status: number,
+  endpointType: SwarmDiscoveryEndpointType,
+): SwarmDiscoveryErrorKind => {
+  if (status === 401 || status === 419) return "auth_needed";
+  if (status === 402 || status === 429) return "cloud_unavailable";
+  if (status === 403) return "rbac_denied";
+  if (endpointType === "local") return "local_unavailable";
+  if (status >= 500) return "cloud_unavailable";
+  return "unknown";
+};
+
+export const getSwarmDiscoveryRecoveryActions = (
+  errorKind: SwarmDiscoveryErrorKind | null,
+): SwarmDiscoveryRecoveryAction[] => {
+  switch (errorKind) {
+    case "auth_needed":
+      return [{ id: "connect-account", label: "Connect ValkyrAI account" }];
+    case "rbac_denied":
+      return [{ id: "swarm-setup", label: "Open Swarm access setup" }];
+    case "cloud_unavailable":
+      return [
+        { id: "retry", label: "Retry discovery" },
+        { id: "buy-credits", label: "Upgrade or buy credits" },
+      ];
+    case "local_unavailable":
+      return [{ id: "swarm-setup", label: "Start or register a local agent" }];
+    case "empty":
+      return [{ id: "swarm-setup", label: "Register first Swarm agent" }];
+    default:
+      return [{ id: "retry", label: "Retry discovery" }];
+  }
+};
+
+const emitSwarmDiscoveryTelemetry = (
+  eventName: string,
+  detail: Record<string, unknown>,
+) => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent("valoride:swarm-discovery", {
+      detail: {
+        eventName,
+        ...detail,
+      },
+    }),
+  );
+};
 
 export function useDiscoveryQuery(
   options: UseDiscoveryQueryOptions,
@@ -39,12 +197,28 @@ export function useDiscoveryQuery(
     refetchInterval = 0,
   } = options;
 
+  const [apiHost, setApiHost] = useState(() => getValkyraiHost());
   const [data, setData] = useState<AgentDiscoveryRecord[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [errorKind, setErrorKind] = useState<SwarmDiscoveryErrorKind | null>(
+    null,
+  );
 
-  const fetchAgents = async () => {
+  const endpointType = useMemo(
+    () => getSwarmDiscoveryEndpointType(apiHost),
+    [apiHost],
+  );
+  const endpoint = useMemo(
+    () =>
+      organizationId
+        ? buildSwarmDiscoveryUrl({ organizationId, status, apiHost })
+        : `${normalizeApiHost(apiHost)}/swarm/agents`,
+    [apiHost, organizationId, status],
+  );
+
+  const fetchAgents = useCallback(async () => {
     if (!enabled || !organizationId) {
       return;
     }
@@ -52,35 +226,66 @@ export function useDiscoveryQuery(
     setIsLoading(true);
     setIsError(false);
     setError(null);
+    setErrorKind(null);
+
+    let failureKind: SwarmDiscoveryErrorKind | null = null;
 
     try {
-      const url = new URL(`${SWARM_API_BASE}/agents`);
-      url.searchParams.set("organizationId", organizationId);
+      const url = buildSwarmDiscoveryUrl({ organizationId, status, apiHost });
+      emitSwarmDiscoveryTelemetry("discovery_endpoint_selected", {
+        endpointType,
+        hasStatusFilter: Boolean(status && status !== "all"),
+      });
 
-      if (status && status !== "all") {
-        url.searchParams.set("status", status);
-      }
-
-      const response = await fetch(url.toString());
+      const response = await fetch(url, {
+        headers: getSwarmDiscoveryHeaders(),
+      });
 
       if (!response.ok) {
-        throw new Error(`Failed to fetch agents: ${response.statusText}`);
+        failureKind = classifySwarmDiscoveryStatus(
+          response.status,
+          endpointType,
+        );
+        setErrorKind(failureKind);
+        throw new Error(
+          `Failed to fetch agents: ${response.status} ${response.statusText}`,
+        );
       }
 
       const result = await response.json();
       const agents = Array.isArray(result)
         ? result
         : result.data || result.agents || [];
+      const nextKind = agents.length === 0 ? "empty" : null;
       setData(agents);
+      setErrorKind(nextKind);
+      emitSwarmDiscoveryTelemetry(
+        agents.length > 0 ? "discovery_success" : "empty_state_shown",
+        {
+          endpointType,
+          agentCount: agents.length,
+        },
+      );
+      if (agents.length > 0) {
+        emitSwarmDiscoveryTelemetry("first_agent_connected", {
+          endpointType,
+        });
+      }
     } catch (err) {
       const error = err instanceof Error ? err : new Error("Unknown error");
+      const kind =
+        failureKind ??
+        (endpointType === "local" ? "local_unavailable" : "cloud_unavailable");
       setIsError(true);
       setError(error);
+      setErrorKind(kind);
       console.error("[useDiscoveryQuery] Error:", error);
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [apiHost, enabled, endpointType, organizationId, status]);
+
+  useEffect(() => subscribeToValkyraiHost(setApiHost), []);
 
   useEffect(() => {
     fetchAgents();
@@ -95,13 +300,17 @@ export function useDiscoveryQuery(
         clearInterval(interval);
       }
     };
-  }, [organizationId, status, enabled, refetchInterval]);
+  }, [fetchAgents, refetchInterval]);
 
   return {
     data,
     isLoading,
     isError,
     error,
+    errorKind,
+    endpoint,
+    endpointType,
+    recoveryActions: getSwarmDiscoveryRecoveryActions(errorKind),
     refetch: fetchAgents,
   };
 }

--- a/webview-ui/src/components/api/hooks/useDiscoveryQuery.ts
+++ b/webview-ui/src/components/api/hooks/useDiscoveryQuery.ts
@@ -1,67 +1,100 @@
 import { useCallback, useEffect, useState } from "react";
+import {
+  buildSwarmDiscoveryUrl,
+  classifySwarmDiscoveryStatus,
+  getSwarmDiscoveryEndpointType,
+  getSwarmDiscoveryHeaders,
+  getSwarmDiscoveryRecoveryActions,
+  type AgentDiscoveryRecord,
+  type SwarmDiscoveryErrorKind,
+  type SwarmDiscoveryRecoveryAction,
+} from "../../../api/hooks/useDiscoveryQuery";
+import {
+  getValkyraiHost,
+  subscribeToValkyraiHost,
+} from "../../../utils/valkyraiHost";
 
-export interface AgentDiscoveryRecord {
-  id: string;
-  username?: string;
-  displayName?: string;
-  status?: "ONLINE" | "OFFLINE" | "IDLE" | "BUSY" | string;
-  [key: string]: any;
-}
+export type { AgentDiscoveryRecord };
 
 export interface UseDiscoveryQueryParams {
   organizationId: string;
   status?: string;
 }
 
-const SWARM_API_BASE = "http://localhost:8080/v1/swarm";
-
-const buildDiscoveryUrl = ({
-  organizationId,
-  status,
-}: UseDiscoveryQueryParams) => {
-  const url = new URL(`${SWARM_API_BASE}/agents/discovery`);
-  url.searchParams.set("organizationId", organizationId);
-  if (status) {
-    url.searchParams.set("status", status);
-  }
-  return url.toString();
-};
-
 export const useDiscoveryQuery = ({
   organizationId,
   status,
 }: UseDiscoveryQueryParams) => {
+  const [apiHost, setApiHost] = useState(() => getValkyraiHost());
   const [data, setData] = useState<AgentDiscoveryRecord[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [errorKind, setErrorKind] = useState<SwarmDiscoveryErrorKind | null>(
+    null,
+  );
+  const [recoveryActions, setRecoveryActions] = useState<
+    SwarmDiscoveryRecoveryAction[]
+  >([]);
 
   const fetchAgents = useCallback(async () => {
     if (!organizationId) {
       setData([]);
+      setErrorKind("empty");
+      setRecoveryActions(getSwarmDiscoveryRecoveryActions("empty"));
       return;
     }
+
+    let failureKind: SwarmDiscoveryErrorKind | null = null;
+    const endpointType = getSwarmDiscoveryEndpointType(apiHost);
 
     try {
       setIsLoading(true);
       setError(null);
+      setErrorKind(null);
+      setRecoveryActions([]);
       const response = await fetch(
-        buildDiscoveryUrl({ organizationId, status }),
+        buildSwarmDiscoveryUrl({
+          organizationId,
+          status,
+          apiHost,
+          path: "agents/discovery",
+        }),
+        { headers: getSwarmDiscoveryHeaders() },
       );
       if (!response.ok) {
+        failureKind = classifySwarmDiscoveryStatus(
+          response.status,
+          endpointType,
+        );
         throw new Error(`Discovery failed: ${response.status}`);
       }
 
-      const payload = (await response.json()) as AgentDiscoveryRecord[];
-      setData(Array.isArray(payload) ? payload : []);
+      const payload = await response.json();
+      const agents = Array.isArray(payload)
+        ? payload
+        : payload.data || payload.agents || [];
+      const nextKind = agents.length === 0 ? "empty" : null;
+      setData(agents);
+      setErrorKind(nextKind);
+      setRecoveryActions(
+        nextKind ? getSwarmDiscoveryRecoveryActions(nextKind) : [],
+      );
     } catch (err) {
+      const kind =
+        failureKind ??
+        (endpointType === "local" ? "local_unavailable" : "cloud_unavailable");
       setError(err as Error);
+      setErrorKind(kind);
+      setRecoveryActions(getSwarmDiscoveryRecoveryActions(kind));
       setData([]);
       // In a webview context we cannot rely on console availability, but this is helpful during dev.
       console.warn("Failed to fetch swarm discovery data", err);
     } finally {
       setIsLoading(false);
     }
-  }, [organizationId, status]);
+  }, [apiHost, organizationId, status]);
+
+  useEffect(() => subscribeToValkyraiHost(setApiHost), []);
 
   useEffect(() => {
     void fetchAgents();
@@ -72,6 +105,17 @@ export const useDiscoveryQuery = ({
     data,
     isLoading,
     error,
+    errorKind,
+    endpoint: organizationId
+      ? buildSwarmDiscoveryUrl({
+          organizationId,
+          status,
+          apiHost,
+          path: "agents/discovery",
+        })
+      : undefined,
+    endpointType: getSwarmDiscoveryEndpointType(apiHost),
+    recoveryActions,
     refetch: fetchAgents,
   };
 };


### PR DESCRIPTION
## Summary
- replaces hardcoded localhost Swarm discovery URLs with configured ValkyrAI host resolution
- subscribes discovery hooks to ValkyrAI host changes so remote/local/enterprise endpoint switches refetch without a webview reload
- attaches existing ValorIDE auth tokens, exposes actionable auth/RBAC/cloud/local/empty recovery states, and emits endpoint/success/empty discovery telemetry events
- adds focused Vitest coverage for hosted URL construction, explicit local fallback, auth headers, error-state classification, host-change refetch, and empty-agent recovery

Refs ValkyrLabs/ValkyrAI#2969

## Verification
- `npm test -- --run src/api/hooks/useDiscoveryQuery.test.tsx`
- `git diff --check`

## Known existing blocker
- `npx tsc --noEmit --pretty false --project tsconfig.json` is blocked before this change by existing merge conflict markers in `../src/shared/ExtensionMessage.tsx`.
