### PR TITLE
feat(graymatter): add quota recovery actions

### DIFF
--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.css
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.css
@@ -115,6 +115,50 @@
   flex: 0 0 auto;
 }
 
+.capability-command-center__quota {
+  align-items: center;
+  background: rgba(210, 153, 34, 0.12);
+  border: 1px solid rgba(210, 153, 34, 0.45);
+  border-radius: 8px;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+  padding: 8px 10px;
+}
+
+.capability-command-center__quota-copy {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+}
+
+.capability-command-center__quota-copy span {
+  line-height: 1.35;
+}
+
+.capability-command-center__quota-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.capability-command-center__quota-actions button {
+  background: var(--vscode-button-background, #0e639c);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--vscode-button-foreground, #ffffff);
+  cursor: pointer;
+  font: inherit;
+  padding: 3px 8px;
+}
+
+.capability-command-center__quota-actions button:hover {
+  background: var(--vscode-button-hoverBackground, #1177bb);
+}
+
 @media (max-width: 640px) {
   .capability-command-center__topline {
     align-items: flex-start;
@@ -124,5 +168,14 @@
   .capability-command-center__model {
     justify-content: flex-start;
     max-width: 100%;
+  }
+
+  .capability-command-center__quota {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .capability-command-center__quota-actions {
+    justify-content: flex-start;
   }
 }

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
@@ -1,17 +1,26 @@
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import CapabilityCommandCenter from "./CapabilityCommandCenter";
 
 const mockUseExtensionState = vi.fn();
+const mockPostMessage = vi.fn();
 
 vi.mock("@thorapi/context/ExtensionStateContext", () => ({
   useExtensionState: () => mockUseExtensionState(),
 }));
 
+vi.mock("@thorapi/utils/vscode", () => ({
+  vscode: {
+    postMessage: (...args: unknown[]) => mockPostMessage(...args),
+  },
+}));
+
 describe("CapabilityCommandCenter", () => {
   beforeEach(() => {
     mockUseExtensionState.mockReset();
+    mockPostMessage.mockReset();
   });
 
   it("summarizes authenticated agentic connections and recent command audit", () => {
@@ -122,5 +131,76 @@ describe("CapabilityCommandCenter", () => {
     expect(screen.getByText("SWARM Offline")).toBeInTheDocument();
     expect(screen.getByText("MCP 0/0")).toBeInTheDocument();
     expect(screen.getByText("No recent remote commands")).toBeInTheDocument();
+  });
+
+  it("turns GrayMatter quota blocks into recharge, upgrade, and usage recovery actions", async () => {
+    const user = userEvent.setup();
+    mockUseExtensionState.mockReturnValue({
+      apiConfiguration: {
+        apiProvider: "openai-native",
+        apiModelId: "gpt-5.5",
+        valkyraiHost: "https://api-0.valkyrlabs.com/v1",
+      },
+      authenticatedUser: {
+        username: "jm",
+      },
+      grayMatterSession: {
+        status: "quota",
+        balanceCredits: 0,
+        estimatedUnlockCredits: 25,
+        lastBlockedAction: {
+          capabilityId: "graymatter.memory",
+          commandId: "cmd-quota-1",
+          label: "Recall project memory",
+        },
+        capabilities: {
+          memoryQuery: true,
+          memoryWrite: true,
+        },
+        checkedAt: "2026-05-13T17:00:00.000Z",
+      },
+      mcpServers: [],
+      agenticState: {
+        swarm: { status: "online" },
+        recentCommands: [
+          {
+            commandId: "cmd-fallback",
+            capabilityId: "terminal.execute",
+            source: "swarm",
+            status: "failed",
+            startedAt: "2026-05-13T17:00:30.000Z",
+            approved: true,
+            requiresApproval: true,
+            toolLabel: "Shell",
+          },
+        ],
+      },
+    });
+
+    render(<CapabilityCommandCenter />);
+
+    expect(screen.getByText("GrayMatter Quota blocked")).toBeInTheDocument();
+    expect(
+      screen.getByText(/GrayMatter is waiting on credits for/i),
+    ).toHaveTextContent(
+      "GrayMatter is waiting on credits for graymatter.memory. Balance: 0 credits. Estimated unlock: 25 credits.",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Recharge credits" }));
+    expect(mockPostMessage).toHaveBeenLastCalledWith({
+      type: "openInBrowser",
+      url: "https://api-0.valkyrlabs.com/buy-credits?source=valoride-graymatter-quota&intent=resume-blocked-action&capability=graymatter.memory&resumeCommand=cmd-quota-1&action=Recall+project+memory",
+    });
+
+    await user.click(screen.getByRole("button", { name: "Upgrade plan" }));
+    expect(mockPostMessage).toHaveBeenLastCalledWith({
+      type: "openInBrowser",
+      url: "https://api-0.valkyrlabs.com/pricing?source=valoride-graymatter-quota&intent=resume-blocked-action&capability=graymatter.memory&resumeCommand=cmd-quota-1&action=Recall+project+memory",
+    });
+
+    await user.click(screen.getByRole("button", { name: "View usage" }));
+    expect(mockPostMessage).toHaveBeenLastCalledWith({
+      type: "showAccountViewClicked",
+    });
   });
 });

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   FaBrain,
+  FaCreditCard,
   FaNetworkWired,
   FaPlug,
   FaRobot,
@@ -10,11 +11,19 @@ import type { AgenticCapabilityCommandCenterState } from "@shared/AgenticState";
 import type { ApiConfiguration } from "@shared/api";
 import type { McpServer } from "@shared/mcp";
 import { useExtensionState } from "@thorapi/context/ExtensionStateContext";
+import { vscode } from "@thorapi/utils/vscode";
 import "./CapabilityCommandCenter.css";
 
 type GrayMatterLike = {
+  balanceCredits?: number;
   capabilities?: Record<string, boolean | undefined>;
   error?: string;
+  estimatedUnlockCredits?: number;
+  lastBlockedAction?: {
+    capabilityId?: string;
+    commandId?: string;
+    label?: string;
+  };
   status?: string;
 };
 
@@ -187,6 +196,64 @@ const commandStatus = (
     : titleCaseStatus(command.status);
 };
 
+const hostedUrl = (path: string, state: Record<string, any>): URL => {
+  const configuredHost = state.apiConfiguration?.valkyraiHost;
+  let origin = "https://valkyrlabs.com";
+  if (typeof configuredHost === "string" && configuredHost.length > 0) {
+    try {
+      origin = new URL(configuredHost).origin;
+    } catch {
+      origin = "https://valkyrlabs.com";
+    }
+  }
+  return new URL(path, origin);
+};
+
+const quotaActionContext = (
+  grayMatterSession: GrayMatterLike | undefined,
+  latestCommand:
+    | AgenticCapabilityCommandCenterState["recentCommands"][number]
+    | undefined,
+) => {
+  const blocked = grayMatterSession?.lastBlockedAction;
+  return {
+    capabilityId: blocked?.capabilityId ?? latestCommand?.capabilityId,
+    commandId: blocked?.commandId ?? latestCommand?.commandId,
+    label: blocked?.label ?? latestCommand?.toolLabel,
+  };
+};
+
+const quotaRecoveryUrl = (
+  path: string,
+  state: Record<string, any>,
+  grayMatterSession: GrayMatterLike | undefined,
+  latestCommand:
+    | AgenticCapabilityCommandCenterState["recentCommands"][number]
+    | undefined,
+): string => {
+  const url = hostedUrl(path, state);
+  const context = quotaActionContext(grayMatterSession, latestCommand);
+  url.searchParams.set("source", "valoride-graymatter-quota");
+  url.searchParams.set("intent", "resume-blocked-action");
+  if (context.capabilityId) {
+    url.searchParams.set("capability", context.capabilityId);
+  }
+  if (context.commandId) {
+    url.searchParams.set("resumeCommand", context.commandId);
+  }
+  if (context.label) {
+    url.searchParams.set("action", context.label);
+  }
+  return url.toString();
+};
+
+const formatCredits = (value?: number): string | undefined => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return `${value.toLocaleString()} credits`;
+};
+
 const StatusPill = ({
   detail,
   icon,
@@ -208,6 +275,55 @@ const StatusPill = ({
     ) : null}
   </div>
 );
+
+const GrayMatterQuotaRecovery = ({
+  grayMatterSession,
+  latestCommand,
+  state,
+}: {
+  grayMatterSession?: GrayMatterLike;
+  latestCommand?: AgenticCapabilityCommandCenterState["recentCommands"][number];
+  state: Record<string, any>;
+}) => {
+  const balance = formatCredits(grayMatterSession?.balanceCredits);
+  const unlockCost = formatCredits(grayMatterSession?.estimatedUnlockCredits);
+  const context = quotaActionContext(grayMatterSession, latestCommand);
+  const blockedAction = context.capabilityId ?? "GrayMatter action";
+
+  const openRecoveryUrl = (path: string) => {
+    vscode.postMessage({
+      type: "openInBrowser",
+      url: quotaRecoveryUrl(path, state, grayMatterSession, latestCommand),
+    });
+  };
+
+  return (
+    <div className="capability-command-center__quota" role="alert">
+      <div className="capability-command-center__quota-copy">
+        <FaCreditCard aria-hidden="true" />
+        <span>
+          GrayMatter is waiting on credits for <strong>{blockedAction}</strong>.
+          {balance ? ` Balance: ${balance}.` : ""}
+          {unlockCost ? ` Estimated unlock: ${unlockCost}.` : ""}
+        </span>
+      </div>
+      <div className="capability-command-center__quota-actions">
+        <button type="button" onClick={() => openRecoveryUrl("/buy-credits")}>
+          Recharge credits
+        </button>
+        <button type="button" onClick={() => openRecoveryUrl("/pricing")}>
+          Upgrade plan
+        </button>
+        <button
+          type="button"
+          onClick={() => vscode.postMessage({ type: "showAccountViewClicked" })}
+        >
+          View usage
+        </button>
+      </div>
+    </div>
+  );
+};
 
 const CapabilityCommandCenter = () => {
   const state = useExtensionState() as Record<string, any>;
@@ -289,6 +405,14 @@ const CapabilityCommandCenter = () => {
           </div>
         )}
       </div>
+
+      {grayMatterSession?.status === "quota" ? (
+        <GrayMatterQuotaRecovery
+          grayMatterSession={grayMatterSession}
+          latestCommand={latestCommand}
+          state={state}
+        />
+      ) : null}
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- add an inline GrayMatter quota recovery panel in the ValorIDE capability command center
- preserve blocked action context in recharge/upgrade URLs for hosted recovery and resume attribution
- add usage/account handoff and focused Vitest coverage for quota CTA behavior

## Verification
- `npm test -- --run src/components/agentic/CapabilityCommandCenter.test.tsx`
- `git diff --check`

## Known blockers
- `npx tsc --noEmit --pretty false --project tsconfig.json` is still blocked by pre-existing merge conflict markers in `../src/shared/ExtensionMessage.tsx` on rc-5.

Closes ValkyrLabs/ValkyrAI#2957
