### PR TITLE
Fix revenue view refresh after pricing saves

### DIFF
--- a/src/services/monetization/pricingEvents.ts
+++ b/src/services/monetization/pricingEvents.ts
@@ -1,0 +1,53 @@
+import type { ManagedMcpService } from "./ServiceMonetizationService";
+
+export const MONETIZATION_PRICING_UPDATED_EVENT =
+  "valoride:monetization-pricing-updated";
+
+export interface MonetizationPricingUpdatedDetail {
+  service: ManagedMcpService;
+  audit: {
+    action: "creator_pricing_updated";
+    serviceId: string;
+    applicationId: string;
+    pricingModel: ManagedMcpService["pricingModel"];
+    costPerCall?: number;
+    recordedAt: string;
+  };
+}
+
+export function dispatchPricingUpdated(service: ManagedMcpService) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<MonetizationPricingUpdatedDetail>(
+      MONETIZATION_PRICING_UPDATED_EVENT,
+      {
+        detail: {
+          service,
+          audit: {
+            action: "creator_pricing_updated",
+            serviceId: service.id,
+            applicationId: service.applicationId,
+            pricingModel: service.pricingModel,
+            costPerCall: service.costPerCall,
+            recordedAt: new Date().toISOString(),
+          },
+        },
+      },
+    ),
+  );
+}
+
+export function isPricingUpdatedEvent(
+  event: Event,
+): event is CustomEvent<MonetizationPricingUpdatedDetail> {
+  return (
+    event.type === MONETIZATION_PRICING_UPDATED_EVENT &&
+    Boolean(
+      (event as CustomEvent<MonetizationPricingUpdatedDetail>).detail?.service
+        ?.id,
+    )
+  );
+}

--- a/src/views/EarningsDashboard.test.tsx
+++ b/src/views/EarningsDashboard.test.tsx
@@ -1,0 +1,114 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import { JSDOM } from "jsdom";
+import type { ManagedMcpService } from "@thorapi/services/monetization/ServiceMonetizationService";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost/",
+});
+
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+(global as any).navigator = dom.window.navigator;
+(global as any).CustomEvent = dom.window.CustomEvent;
+
+jest.mock("./EarningsDashboard.css", () => ({}));
+
+jest.mock("@thorapi/services/monetization/ServiceMonetizationService", () => ({
+  getCreatorServices: jest.fn(),
+  getMonthlyEarnings: jest.fn(),
+  getTotalEarnings: jest.fn(),
+}));
+
+const React = require("react");
+const { act, render, screen, waitFor } = require("@testing-library/react");
+require("@testing-library/jest-dom");
+
+const { EarningsDashboard } = require("./EarningsDashboard");
+const {
+  getCreatorServices,
+  getMonthlyEarnings,
+  getTotalEarnings,
+} = require("@thorapi/services/monetization/ServiceMonetizationService");
+const {
+  MONETIZATION_PRICING_UPDATED_EVENT,
+} = require("@thorapi/services/monetization/pricingEvents");
+
+const getCreatorServicesMock = getCreatorServices as jest.MockedFunction<
+  () => Promise<ManagedMcpService[]>
+>;
+const getMonthlyEarningsMock = getMonthlyEarnings as jest.MockedFunction<
+  () => Promise<{
+    month: string;
+    totalEarned: number;
+    totalInvocations: number;
+    payoutStatus: "PENDING";
+  }>
+>;
+const getTotalEarningsMock = getTotalEarnings as jest.MockedFunction<
+  () => Promise<{ totalAllTimeEarnings: number }>
+>;
+
+function service(overrides: Partial<ManagedMcpService> = {}) {
+  return {
+    id: "svc-123",
+    applicationId: "app-123",
+    name: "Revenue Bot",
+    createdBy: "creator-1",
+    status: "MONETIZED",
+    pricingModel: "PER_CALL",
+    costPerCall: 5,
+    hideFromMarketplace: false,
+    isMonetized: true,
+    createdAt: "2026-05-21T00:00:00.000Z",
+    updatedAt: "2026-05-21T00:00:00.000Z",
+    ...overrides,
+  } satisfies ManagedMcpService;
+}
+
+describe("EarningsDashboard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = "";
+    getTotalEarningsMock.mockResolvedValue({ totalAllTimeEarnings: 42 });
+    getMonthlyEarningsMock.mockResolvedValue({
+      month: "2026-05",
+      totalEarned: 10,
+      totalInvocations: 20,
+      payoutStatus: "PENDING",
+    });
+  });
+
+  it("refreshes creator service pricing after a pricing save event", async () => {
+    getCreatorServicesMock
+      .mockResolvedValueOnce([service({ costPerCall: 5 })])
+      .mockResolvedValueOnce([service({ costPerCall: 11 })]);
+
+    render(<EarningsDashboard />);
+
+    await screen.findByText("Revenue Bot");
+    expect(screen.getByText("5")).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(MONETIZATION_PRICING_UPDATED_EVENT, {
+          detail: {
+            service: service({ costPerCall: 11 }),
+            audit: {
+              action: "creator_pricing_updated",
+              serviceId: "svc-123",
+              applicationId: "app-123",
+              pricingModel: "PER_CALL",
+              costPerCall: 11,
+              recordedAt: "2026-05-22T00:00:00.000Z",
+            },
+          },
+        }),
+      );
+    });
+
+    await waitFor(() =>
+      expect(getCreatorServicesMock).toHaveBeenCalledTimes(2),
+    );
+    expect(await screen.findByText("11")).toBeInTheDocument();
+  });
+});

--- a/src/views/EarningsDashboard.tsx
+++ b/src/views/EarningsDashboard.tsx
@@ -6,6 +6,10 @@ import {
   getCreatorServices,
   ManagedMcpService,
 } from "@thorapi/services/monetization/ServiceMonetizationService";
+import {
+  MONETIZATION_PRICING_UPDATED_EVENT,
+  isPricingUpdatedEvent,
+} from "@thorapi/services/monetization/pricingEvents";
 import "./EarningsDashboard.css";
 
 /**
@@ -26,6 +30,36 @@ export const EarningsDashboard: React.FC = () => {
 
   useEffect(() => {
     loadData();
+  }, [selectedMonth]);
+
+  useEffect(() => {
+    const handlePricingUpdated = (event: Event) => {
+      if (!isPricingUpdatedEvent(event)) {
+        return;
+      }
+
+      const updatedService = event.detail.service;
+      setServices((current) =>
+        current.map((service) =>
+          service.id === updatedService.id
+            ? { ...service, ...updatedService }
+            : service,
+        ),
+      );
+      void loadData();
+    };
+
+    window.addEventListener(
+      MONETIZATION_PRICING_UPDATED_EVENT,
+      handlePricingUpdated,
+    );
+
+    return () => {
+      window.removeEventListener(
+        MONETIZATION_PRICING_UPDATED_EVENT,
+        handlePricingUpdated,
+      );
+    };
   }, [selectedMonth]);
 
   const loadData = async () => {

--- a/src/views/MonetizationSettings.test.tsx
+++ b/src/views/MonetizationSettings.test.tsx
@@ -19,17 +19,28 @@ jest.mock("@thorapi/services/monetization/ServiceMonetizationService", () => ({
 }));
 
 const React = require("react");
-const { fireEvent, render, screen, waitFor } = require("@testing-library/react");
+const {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} = require("@testing-library/react");
 require("@testing-library/jest-dom");
 
+const { MonetizationSettings } = require("./MonetizationSettings");
+const {
+  updatePricing,
+} = require("@thorapi/services/monetization/ServiceMonetizationService");
 const {
   MONETIZATION_PRICING_UPDATED_EVENT,
-  MonetizationSettings,
-} = require("./MonetizationSettings");
-const { updatePricing } = require("@thorapi/services/monetization/ServiceMonetizationService");
+} = require("@thorapi/services/monetization/pricingEvents");
 
 const updatePricingMock = updatePricing as jest.MockedFunction<
-  (serviceId: string, pricingModel: string, costPerCall: number) => Promise<ManagedMcpService>
+  (
+    serviceId: string,
+    pricingModel: string,
+    costPerCall: number,
+  ) => Promise<ManagedMcpService>
 >;
 
 function monetizedService(overrides: Partial<ManagedMcpService> = {}) {
@@ -120,7 +131,10 @@ describe("MonetizationSettings", () => {
 
   it("blocks invalid pricing before calling the backend", async () => {
     render(
-      <MonetizationSettings applicationId="app-123" service={monetizedService()} />,
+      <MonetizationSettings
+        applicationId="app-123"
+        service={monetizedService()}
+      />,
     );
 
     fireEvent.change(screen.getByLabelText(/cost per call/i), {
@@ -142,17 +156,24 @@ describe("MonetizationSettings", () => {
     );
 
     render(
-      <MonetizationSettings applicationId="app-123" service={monetizedService()} />,
+      <MonetizationSettings
+        applicationId="app-123"
+        service={monetizedService()}
+      />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: /update pricing/i }));
 
-    expect(await screen.findByRole("button", { name: /updating/i })).toBeDisabled();
+    expect(
+      await screen.findByRole("button", { name: /updating/i }),
+    ).toBeDisabled();
 
     resolveSave(monetizedService({ costPerCall: 6 }));
 
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: /update pricing/i })).toBeEnabled(),
+      expect(
+        screen.getByRole("button", { name: /update pricing/i }),
+      ).toBeEnabled(),
     );
   });
 });

--- a/src/views/MonetizationSettings.tsx
+++ b/src/views/MonetizationSettings.tsx
@@ -5,10 +5,8 @@ import {
   enableMonetization,
   updatePricing,
 } from "@thorapi/services/monetization/ServiceMonetizationService";
+import { dispatchPricingUpdated } from "@thorapi/services/monetization/pricingEvents";
 import "./MonetizationSettings.css";
-
-export const MONETIZATION_PRICING_UPDATED_EVENT =
-  "valoride:monetization-pricing-updated";
 
 interface MonetizationSettingsProps {
   applicationId: string;
@@ -26,28 +24,6 @@ function validatePrice(costPerCall: number): string | null {
   return null;
 }
 
-function notifyPricingUpdated(service: ManagedMcpService) {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  window.dispatchEvent(
-    new CustomEvent(MONETIZATION_PRICING_UPDATED_EVENT, {
-      detail: {
-        service,
-        audit: {
-          action: "creator_pricing_updated",
-          serviceId: service.id,
-          applicationId: service.applicationId,
-          pricingModel: service.pricingModel,
-          costPerCall: service.costPerCall,
-          recordedAt: new Date().toISOString(),
-        },
-      },
-    }),
-  );
-}
-
 /**
  * Component to enable and configure monetization on MCP services.
  * Only accessible to RESELLER and PRO/ENTERPRISE users.
@@ -62,9 +38,7 @@ export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
   const [resolvedServiceId, setResolvedServiceId] = useState(
     service?.id ?? serviceId ?? "",
   );
-  const [isMonetized, setIsMonetized] = useState(
-    service?.isMonetized ?? false,
-  );
+  const [isMonetized, setIsMonetized] = useState(service?.isMonetized ?? false);
   const [pricingModel, setPricingModel] = useState<PricingModel>(
     service?.pricingModel ?? "PER_CALL",
   );
@@ -94,7 +68,7 @@ export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
     setCostPerCall(result.costPerCall ?? costPerCall);
     setSuccess(true);
     onSuccess?.(result);
-    notifyPricingUpdated(result);
+    dispatchPricingUpdated(result);
 
     // Auto-hide success message after 3s
     setTimeout(() => setSuccess(false), 3000);

--- a/src/views/MonetizedServicesMarketplace.test.tsx
+++ b/src/views/MonetizedServicesMarketplace.test.tsx
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import { JSDOM } from "jsdom";
+import type { ManagedMcpService } from "@thorapi/services/monetization/ServiceMonetizationService";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost/",
+});
+
+(global as any).window = dom.window;
+(global as any).document = dom.window.document;
+(global as any).navigator = dom.window.navigator;
+(global as any).CustomEvent = dom.window.CustomEvent;
+
+jest.mock("./MonetizedServicesMarketplace.css", () => ({}));
+
+jest.mock("@thorapi/services/monetization/ServiceMonetizationService", () => ({
+  getMarketplaceServices: jest.fn(),
+  subscribeToService: jest.fn(),
+}));
+
+const React = require("react");
+const { act, render, screen, waitFor } = require("@testing-library/react");
+require("@testing-library/jest-dom");
+
+const {
+  MonetizedServicesMarketplace,
+} = require("./MonetizedServicesMarketplace");
+const {
+  getMarketplaceServices,
+} = require("@thorapi/services/monetization/ServiceMonetizationService");
+const {
+  MONETIZATION_PRICING_UPDATED_EVENT,
+} = require("@thorapi/services/monetization/pricingEvents");
+
+const getMarketplaceServicesMock =
+  getMarketplaceServices as jest.MockedFunction<
+    () => Promise<ManagedMcpService[]>
+  >;
+
+function service(overrides: Partial<ManagedMcpService> = {}) {
+  return {
+    id: "svc-123",
+    applicationId: "app-123",
+    name: "Revenue Bot",
+    createdBy: "creator-1",
+    status: "MONETIZED",
+    pricingModel: "PER_CALL",
+    costPerCall: 5,
+    hideFromMarketplace: false,
+    isMonetized: true,
+    createdAt: "2026-05-21T00:00:00.000Z",
+    updatedAt: "2026-05-21T00:00:00.000Z",
+    ...overrides,
+  } satisfies ManagedMcpService;
+}
+
+describe("MonetizedServicesMarketplace", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("refreshes marketplace pricing after a creator pricing save event", async () => {
+    getMarketplaceServicesMock
+      .mockResolvedValueOnce([service({ costPerCall: 5 })])
+      .mockResolvedValueOnce([service({ costPerCall: 9 })]);
+
+    render(<MonetizedServicesMarketplace />);
+
+    await screen.findByText("Revenue Bot");
+    expect(screen.getByText("5")).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(MONETIZATION_PRICING_UPDATED_EVENT, {
+          detail: {
+            service: service({ costPerCall: 9 }),
+            audit: {
+              action: "creator_pricing_updated",
+              serviceId: "svc-123",
+              applicationId: "app-123",
+              pricingModel: "PER_CALL",
+              costPerCall: 9,
+              recordedAt: "2026-05-22T00:00:00.000Z",
+            },
+          },
+        }),
+      );
+    });
+
+    await screen.findByText(/marketplace refreshed/i);
+    await waitFor(() =>
+      expect(getMarketplaceServicesMock).toHaveBeenCalledTimes(2),
+    );
+    expect(await screen.findByText("9")).toBeInTheDocument();
+  });
+});

--- a/src/views/MonetizedServicesMarketplace.tsx
+++ b/src/views/MonetizedServicesMarketplace.tsx
@@ -5,6 +5,10 @@ import {
   getMarketplaceServices,
   subscribeToService,
 } from "@thorapi/services/monetization/ServiceMonetizationService";
+import {
+  MONETIZATION_PRICING_UPDATED_EVENT,
+  isPricingUpdatedEvent,
+} from "@thorapi/services/monetization/pricingEvents";
 import "./MonetizedServicesMarketplace.css";
 
 /**
@@ -15,9 +19,8 @@ export const MonetizedServicesMarketplace: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [subscribing, setSubscribing] = useState<string | null>(null);
-  const [selectedService, setSelectedService] = useState<ManagedMcpService | null>(
-    null,
-  );
+  const [selectedService, setSelectedService] =
+    useState<ManagedMcpService | null>(null);
   const [subscriptionType, setSubscriptionType] =
     useState<SubscriptionType>("PAY_AS_YOU_GO");
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -29,6 +32,43 @@ export const MonetizedServicesMarketplace: React.FC = () => {
 
   useEffect(() => {
     loadServices();
+  }, []);
+
+  useEffect(() => {
+    const handlePricingUpdated = (event: Event) => {
+      if (!isPricingUpdatedEvent(event)) {
+        return;
+      }
+
+      const updatedService = event.detail.service;
+      setServices((current) =>
+        current.map((service) =>
+          service.id === updatedService.id
+            ? { ...service, ...updatedService }
+            : service,
+        ),
+      );
+      setSelectedService((current) =>
+        current?.id === updatedService.id
+          ? { ...current, ...updatedService }
+          : current,
+      );
+      setStatusTone("success");
+      setStatusMessage("Marketplace refreshed with the saved creator pricing.");
+      void loadServices();
+    };
+
+    window.addEventListener(
+      MONETIZATION_PRICING_UPDATED_EVENT,
+      handlePricingUpdated,
+    );
+
+    return () => {
+      window.removeEventListener(
+        MONETIZATION_PRICING_UPDATED_EVENT,
+        handlePricingUpdated,
+      );
+    };
   }, []);
 
   const loadServices = async () => {
@@ -243,7 +283,10 @@ export const MonetizedServicesMarketplace: React.FC = () => {
       )}
 
       {selectedService && (
-        <div className="service-modal-backdrop" onClick={() => setSelectedService(null)}>
+        <div
+          className="service-modal-backdrop"
+          onClick={() => setSelectedService(null)}
+        >
           <div className="service-modal" onClick={(e) => e.stopPropagation()}>
             <h2>{selectedService.name}</h2>
             <p>{selectedService.description || "No description available"}</p>
@@ -251,28 +294,38 @@ export const MonetizedServicesMarketplace: React.FC = () => {
               <div>Creator: {selectedService.createdBy}</div>
               <div>Pricing Model: {selectedService.pricingModel}</div>
               <div>
-                Est. Credits/Call: {selectedService.costPerCall ?? "Not specified"}
+                Est. Credits/Call:{" "}
+                {selectedService.costPerCall ?? "Not specified"}
               </div>
             </div>
             <label htmlFor="subscriptionType">Plan</label>
             <select
               id="subscriptionType"
               value={subscriptionType}
-              onChange={(e) => setSubscriptionType(e.target.value as SubscriptionType)}
+              onChange={(e) =>
+                setSubscriptionType(e.target.value as SubscriptionType)
+              }
             >
               <option value="PAY_AS_YOU_GO">Pay as you go</option>
               <option value="MONTHLY">Monthly</option>
             </select>
             <div className="modal-actions">
-              <button className="btn btn-details" onClick={() => setSelectedService(null)}>
+              <button
+                className="btn btn-details"
+                onClick={() => setSelectedService(null)}
+              >
                 Cancel
               </button>
               <button
                 className="btn btn-subscribe"
                 disabled={subscribing === selectedService.id}
-                onClick={() => handleSubscribe(selectedService.id, subscriptionType)}
+                onClick={() =>
+                  handleSubscribe(selectedService.id, subscriptionType)
+                }
               >
-                {subscribing === selectedService.id ? "Subscribing..." : "Subscribe"}
+                {subscribing === selectedService.id
+                  ? "Subscribing..."
+                  : "Subscribe"}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Extract creator pricing save broadcasts into a shared pricing event helper with audit metadata
- Refresh marketplace cards/modals when a pricing save event lands
- Refresh creator earnings service pricing after saved creator pricing changes

Fixes ValkyrLabs/ValkyrAI#2804

## Tests
- npx jest src/views/MonetizationSettings.test.tsx src/views/MonetizedServicesMarketplace.test.tsx src/views/EarningsDashboard.test.tsx --runInBand --forceExit
- npx eslint src/services/monetization/pricingEvents.ts src/views/MonetizationSettings.tsx src/views/MonetizationSettings.test.tsx src/views/MonetizedServicesMarketplace.tsx src/views/MonetizedServicesMarketplace.test.tsx src/views/EarningsDashboard.tsx src/views/EarningsDashboard.test.tsx

## Notes
- npx tsc --noEmit --pretty false --project tsconfig.json is currently blocked by pre-existing merge conflict markers/syntax errors in unrelated communication/shared files on rc-5.