### PR TITLE
feat(credits): preserve blocked action intent

### DIFF
--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -36,7 +36,10 @@ import {
 import McpView from "./components/mcp/configuration/McpConfigurationView";
 import { McpViewTab } from "@shared/mcp";
 import { CREDIT_INTENT_EVENT, CreditIntent } from "./types/creditIntent";
-import { clearAccountBalancePrompt } from "./redux/slices/apiErrorsSlice";
+import {
+  clearAccountBalancePrompt,
+  clearCreditIntent,
+} from "./redux/slices/apiErrorsSlice";
 
 const AppContent = () => {
   const {
@@ -49,6 +52,9 @@ const AppContent = () => {
   const dispatch = useDispatch();
   const showAccountBalance = useSelector(
     (state: any) => state?.apiErrors?.showAccountBalance,
+  );
+  const apiErrorCreditIntent = useSelector(
+    (state: any) => state?.apiErrors?.creditIntent,
   );
   const [hasStoredAuth, setHasStoredAuth] = useState(false);
 
@@ -300,7 +306,10 @@ const AppContent = () => {
       setAccountInitialActiveTab("account");
     };
 
-    window.addEventListener(CREDIT_INTENT_EVENT, handleCreditIntent as EventListener);
+    window.addEventListener(
+      CREDIT_INTENT_EVENT,
+      handleCreditIntent as EventListener,
+    );
     return () =>
       window.removeEventListener(
         CREDIT_INTENT_EVENT,
@@ -327,9 +336,12 @@ const AppContent = () => {
     setShowApplicationProgress(false);
     setShowFileExplorer(true);
     setAccountInitialActiveTab("account");
+    if (apiErrorCreditIntent) {
+      setCreditIntent(apiErrorCreditIntent);
+    }
 
     dispatch(clearAccountBalancePrompt());
-  }, [dispatch, showAccountBalance]);
+  }, [apiErrorCreditIntent, dispatch, showAccountBalance]);
 
   const handleFileSelect = useCallback((filePath: string) => {
     // Use openMention to open the selected file
@@ -389,9 +401,14 @@ const AppContent = () => {
                 setServerConsoleNeedsAttention(false)
               }
               initialActiveTab={accountInitialActiveTab}
-              onConsumeInitialActiveTab={() => setAccountInitialActiveTab(undefined)}
+              onConsumeInitialActiveTab={() =>
+                setAccountInitialActiveTab(undefined)
+              }
               creditIntent={creditIntent}
-              onClearCreditIntent={() => setCreditIntent(undefined)}
+              onClearCreditIntent={() => {
+                setCreditIntent(undefined);
+                dispatch(clearCreditIntent());
+              }}
             />
           )}
           {showGeneratedFiles && <GeneratedFilesView />}

--- a/webview-ui/src/redux/middleware/apiErrorListener.test.ts
+++ b/webview-ui/src/redux/middleware/apiErrorListener.test.ts
@@ -53,7 +53,13 @@ describe("apiErrorListener", () => {
       type: "fake/rejected",
       payload: {
         status: 402,
-        data: { error: "INSUFFICIENT_CREDITS", message: "insufficient" },
+        data: {
+          error: "INSUFFICIENT_CREDITS",
+          message: "insufficient",
+          requiredCredits: 4,
+          currentBalance: 0.5,
+          actionName: "Generate paid app",
+        },
       },
       meta: {
         arg: { endpointName: "generateApplication" },
@@ -71,6 +77,44 @@ describe("apiErrorListener", () => {
     expect((state.lastError as ApiErrorPayload).endpointName).toBe(
       "generateApplication",
     );
+    expect(state.creditIntent).toMatchObject({
+      actionName: "Generate paid app",
+      requiredCredits: 4,
+      currentBalance: 0.5,
+      originView: "generateApplication",
+    });
+  });
+
+  it("builds a task-aware credit intent from generic insufficient funds payloads", async () => {
+    const store = makeStore();
+
+    store.dispatch({
+      type: "fake/rejected",
+      payload: {
+        status: 402,
+        data: {
+          error: "INSUFFICIENT_FUNDS",
+          cost: "2.25",
+          balance: "0.25",
+        },
+      },
+      meta: {
+        arg: { endpointName: "activateAgent" },
+        requestId: "r1b",
+        rejectedWithValue: true,
+        requestStatus: "rejected",
+      },
+      error: { message: "Rejected" },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(store.getState().apiErrors.creditIntent).toMatchObject({
+      actionName: "Activate Agent",
+      requiredCredits: 2.25,
+      currentBalance: 0.25,
+      resumeLabel: "Return after top-up",
+    });
   });
 
   it("stores generic api errors for non credit failures", async () => {

--- a/webview-ui/src/redux/middleware/apiErrorListener.ts
+++ b/webview-ui/src/redux/middleware/apiErrorListener.ts
@@ -10,6 +10,30 @@ import {
   type ApiErrorPayload,
 } from "../slices/apiErrorsSlice";
 import { clearStoredAuthSession } from "@thorapi/utils/accessControl";
+import { CreditIntent } from "../../types/creditIntent";
+
+const firstFiniteNumber = (...values: unknown[]): number | undefined => {
+  for (const value of values) {
+    const numericValue =
+      typeof value === "number"
+        ? value
+        : typeof value === "string" && value.trim() !== ""
+          ? Number(value)
+          : Number.NaN;
+    if (Number.isFinite(numericValue)) {
+      return numericValue;
+    }
+  }
+  return undefined;
+};
+
+const titleizeEndpoint = (endpointName?: string): string => {
+  if (!endpointName) return "ValorIDE action";
+  return endpointName
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .replace(/^./, (char) => char.toUpperCase());
+};
 
 const isInsufficientCreditsPayload = (data: any): boolean => {
   if (!data) return false;
@@ -36,6 +60,47 @@ const buildMessage = (status: number, data: any): string => {
   } catch {
     return `Request failed with status ${status}`;
   }
+};
+
+const buildCreditIntent = (data: any, endpointName?: string): CreditIntent => {
+  const requiredCredits = Math.max(
+    0.01,
+    firstFiniteNumber(
+      data?.requiredCredits,
+      data?.creditsRequired,
+      data?.required,
+      data?.estimatedCredits,
+      data?.estimatedCost,
+      data?.cost,
+      data?.minimumTopUp,
+      data?.neededCredits,
+    ) ?? 1,
+  );
+  const currentBalance = Math.max(
+    0,
+    firstFiniteNumber(
+      data?.currentBalance,
+      data?.balance,
+      data?.availableCredits,
+      data?.creditBalance,
+    ) ?? 0,
+  );
+
+  return {
+    actionName:
+      (typeof data?.actionName === "string" && data.actionName) ||
+      (typeof data?.operation === "string" && data.operation) ||
+      titleizeEndpoint(endpointName),
+    requiredCredits,
+    currentBalance,
+    originView:
+      (typeof data?.originView === "string" && data.originView) || endpointName,
+    resumeLabel:
+      (typeof data?.resumeLabel === "string" && data.resumeLabel) ||
+      "Return after top-up",
+    resumeUrl: typeof data?.resumeUrl === "string" ? data.resumeUrl : undefined,
+    messageTs: Date.now(),
+  };
 };
 
 const isExpiredSessionPayload = (status: number, data: any): boolean => {
@@ -82,7 +147,12 @@ apiErrorListener.startListening({
     }
 
     if (isInsufficientCreditsPayload(data)) {
-      listenerApi.dispatch(insufficientCreditsDetected(errorPayload));
+      listenerApi.dispatch(
+        insufficientCreditsDetected({
+          error: errorPayload,
+          creditIntent: buildCreditIntent(data, endpointName),
+        }),
+      );
       return;
     }
 

--- a/webview-ui/src/redux/slices/apiErrorsSlice.test.ts
+++ b/webview-ui/src/redux/slices/apiErrorsSlice.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import reducer, {
   apiErrorReceived,
   clearAccountBalancePrompt,
+  clearCreditIntent,
   insufficientCreditsDetected,
 } from "./apiErrorsSlice";
 
@@ -21,17 +22,45 @@ describe("apiErrorsSlice", () => {
   });
 
   it("flags account balance prompt for insufficient credits", () => {
-    const state = reducer(undefined, insufficientCreditsDetected(baseError));
+    const state = reducer(
+      undefined,
+      insufficientCreditsDetected({
+        error: baseError,
+        creditIntent: {
+          actionName: "Generate application",
+          requiredCredits: 3,
+          currentBalance: 0.25,
+        },
+      }),
+    );
     expect(state.lastError).toEqual(baseError);
     expect(state.showAccountBalance).toBe(true);
+    expect(state.creditIntent?.actionName).toBe("Generate application");
   });
 
   it("clears account balance prompt", () => {
     const withPrompt = reducer(
       undefined,
-      insufficientCreditsDetected(baseError),
+      insufficientCreditsDetected({ error: baseError }),
     );
     const cleared = reducer(withPrompt, clearAccountBalancePrompt());
     expect(cleared.showAccountBalance).toBe(false);
+  });
+
+  it("clears the task-aware credit intent after purchase or resume", () => {
+    const withIntent = reducer(
+      undefined,
+      insufficientCreditsDetected({
+        error: baseError,
+        creditIntent: {
+          actionName: "Run agent",
+          requiredCredits: 2,
+          currentBalance: 0,
+        },
+      }),
+    );
+
+    const cleared = reducer(withIntent, clearCreditIntent());
+    expect(cleared.creditIntent).toBeUndefined();
   });
 });

--- a/webview-ui/src/redux/slices/apiErrorsSlice.ts
+++ b/webview-ui/src/redux/slices/apiErrorsSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { CreditIntent } from "../../types/creditIntent";
 
 export interface ApiErrorPayload {
   id: string;
@@ -11,11 +12,13 @@ export interface ApiErrorPayload {
 interface ApiErrorsState {
   lastError: ApiErrorPayload | null;
   showAccountBalance: boolean;
+  creditIntent?: CreditIntent;
 }
 
 const initialState: ApiErrorsState = {
   lastError: null,
   showAccountBalance: false,
+  creditIntent: undefined,
 };
 
 const apiErrorsSlice = createSlice({
@@ -27,16 +30,23 @@ const apiErrorsSlice = createSlice({
     },
     insufficientCreditsDetected: (
       state,
-      action: PayloadAction<ApiErrorPayload>,
+      action: PayloadAction<{
+        error: ApiErrorPayload;
+        creditIntent?: CreditIntent;
+      }>,
     ) => {
-      state.lastError = action.payload;
+      state.lastError = action.payload.error;
       state.showAccountBalance = true;
+      state.creditIntent = action.payload.creditIntent;
     },
     clearLastError: (state) => {
       state.lastError = null;
     },
     clearAccountBalancePrompt: (state) => {
       state.showAccountBalance = false;
+    },
+    clearCreditIntent: (state) => {
+      state.creditIntent = undefined;
     },
   },
 });
@@ -46,6 +56,7 @@ export const {
   insufficientCreditsDetected,
   clearLastError,
   clearAccountBalancePrompt,
+  clearCreditIntent,
 } = apiErrorsSlice.actions;
 
 export default apiErrorsSlice.reducer;


### PR DESCRIPTION
## Summary
- capture insufficient-credit API payloads as task-aware credit intents
- route blocked users to Account with action, cost, balance, and resume context intact
- clear the intent after purchase/resume and cover reducer/listener behavior with Vitest

## Tests
- npx vitest run src/redux/slices/apiErrorsSlice.test.ts src/redux/middleware/apiErrorListener.test.ts

## Notes
- Full npm test is currently blocked by pre-existing TypeScript syntax/conflict errors in RemoteCodingSession* and src/shared/ExtensionMessage.tsx.
- AccountView focused tests are currently blocked by missing react-bootstrap resolution in the webview Vitest environment.

Refs ValkyrLabs/ValkyrAI#2846