### PR TITLE
feat: activation CTAs for unauthenticated Capability Command Center state

### DIFF
--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
@@ -30,11 +30,16 @@ describe("CapabilityCommandCenter", () => {
   it("maps every degraded capability state to a recovery or upsell action", () => {
     const cards = deriveCapabilityCards(degradedSnapshots);
 
-    expect(
-      cards
-        .find((card) => card.status === "unauthenticated")
-        ?.actions.map((action) => action.action),
-    ).toContain("signIn");
+    const unauthenticatedCard = cards.find(
+      (card) => card.status === "unauthenticated",
+    );
+
+    expect(unauthenticatedCard?.actions.map((action) => action.action)).toContain(
+      "signIn",
+    );
+    expect(unauthenticatedCard?.actions.map((action) => action.label)).toEqual(
+      expect.arrayContaining(["Sign in to ValkyrAI", "Create workspace"]),
+    );
     expect(
       cards
         .find((card) => card.status === "rbacDenied")

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
@@ -75,14 +75,14 @@ const ACTIONS_BY_STATUS: Record<CapabilityStatus, CapabilityActionModel[]> = {
   unauthenticated: [
     {
       action: "signIn",
-      label: "Sign in",
+      label: "Sign in to ValkyrAI",
       detail: "Authenticate ValorIDE before using GrayMatter memory.",
       variant: "primary",
     },
     {
       action: "setupGrayMatter",
-      label: "Setup guide",
-      detail: "Open the account and activation path for GrayMatter setup.",
+      label: "Create workspace",
+      detail: "Open the activation path and return to ValorIDE when setup completes.",
       variant: "secondary",
     },
   ],


### PR DESCRIPTION
## Summary\n- updates unauthenticated Capability Command Center CTA copy to match activation flow intent\n- uses explicit "Sign in to ValkyrAI" and "Create workspace" actions\n- extends unit expectations so degraded-state mapping guards the new CTA labels\n\n## Validation\n-  *(blocked: vitest not installed in this workspace clone)*\n\nRefs: https://github.com/ValkyrLabs/ValkyrAI/issues/2859