### PR TITLE
feat: add activation recovery CTAs to command center (#2859)

### DIFF
--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
@@ -203,4 +203,69 @@ describe("CapabilityCommandCenter", () => {
       type: "showAccountViewClicked",
     });
   });
+
+  it("shows sign-in and workspace recovery actions for unauthenticated sessions", async () => {
+    const user = userEvent.setup();
+    mockUseExtensionState.mockReturnValue({
+      apiConfiguration: {
+        valkyraiHost: "https://api-0.valkyrlabs.com/v1",
+      },
+      grayMatterSession: {
+        status: "unauthenticated",
+      },
+      mcpServers: [],
+    });
+
+    render(<CapabilityCommandCenter />);
+
+    await user.click(screen.getByRole("button", { name: "Sign in to ValkyrAI" }));
+    expect(mockPostMessage).toHaveBeenLastCalledWith({
+      type: "openInBrowser",
+      url: "https://api-0.valkyrlabs.com/graymatter/activate?source=valoride-graymatter-auth",
+    });
+
+    await user.click(screen.getByRole("button", { name: "Create workspace" }));
+    expect(mockPostMessage).toHaveBeenLastCalledWith({
+      type: "openInBrowser",
+      url: "https://api-0.valkyrlabs.com/signup?source=valoride-graymatter-workspace",
+    });
+  });
+
+  it("surfaces RBAC, unavailable, and MCP recovery actions", async () => {
+    const user = userEvent.setup();
+    mockUseExtensionState.mockReturnValue({
+      apiConfiguration: {
+        valkyraiHost: "https://api-0.valkyrlabs.com/v1",
+      },
+      grayMatterSession: {
+        status: "forbidden",
+      },
+      mcpServers: [{ name: "broken", status: "disconnected", disabled: false }],
+    });
+
+    render(<CapabilityCommandCenter />);
+
+    await user.click(screen.getByRole("button", { name: "Request access" }));
+    expect(mockPostMessage).toHaveBeenLastCalledWith({
+      type: "openInBrowser",
+      url: "https://api-0.valkyrlabs.com/account?source=valoride-graymatter-rbac-request",
+    });
+
+    await user.click(screen.getByRole("button", { name: "Open admin RBAC" }));
+    expect(mockPostMessage).toHaveBeenLastCalledWith({
+      type: "openInBrowser",
+      url: "https://api-0.valkyrlabs.com/admin/rbac?source=valoride-graymatter-rbac-admin",
+    });
+
+    await user.click(screen.getByRole("button", { name: "Retry discovery" }));
+    expect(mockPostMessage).toHaveBeenLastCalledWith({
+      type: "fetchLatestMcpServersFromHub",
+    });
+
+    await user.click(screen.getByRole("button", { name: "Open MCP setup" }));
+    expect(mockPostMessage).toHaveBeenLastCalledWith({
+      type: "mcpButtonClicked",
+      tab: "installed",
+    });
+  });
 });

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
@@ -270,6 +270,97 @@ const GrayMatterQuotaRecovery = ({
   );
 };
 
+const GrayMatterRecoveryActions = ({
+  grayMatterSession,
+  state,
+}: {
+  grayMatterSession?: GrayMatterLike;
+  state: Record<string, any>;
+}) => {
+  const openHosted = (path: string, source: string) => {
+    const url = hostedUrl(path, state);
+    url.searchParams.set("source", source);
+    vscode.postMessage({ type: "openInBrowser", url: url.toString() });
+  };
+
+  if (grayMatterSession?.status === "unauthenticated") {
+    return (
+      <div className="capability-command-center__quota" role="alert">
+        <div className="capability-command-center__quota-copy">
+          <FaCreditCard aria-hidden="true" />
+          <span>Sign in to restore GrayMatter memory and activation flows.</span>
+        </div>
+        <div className="capability-command-center__quota-actions">
+          <button
+            type="button"
+            onClick={() => openHosted("/graymatter/activate", "valoride-graymatter-auth")}
+          >
+            Sign in to ValkyrAI
+          </button>
+          <button
+            type="button"
+            onClick={() => openHosted("/signup", "valoride-graymatter-workspace")}
+          >
+            Create workspace
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (grayMatterSession?.status === "forbidden") {
+    return (
+      <div className="capability-command-center__quota" role="alert">
+        <div className="capability-command-center__quota-copy">
+          <FaCreditCard aria-hidden="true" />
+          <span>Missing role/scope detected. Request access or open RBAC controls.</span>
+        </div>
+        <div className="capability-command-center__quota-actions">
+          <button
+            type="button"
+            onClick={() => openHosted("/account", "valoride-graymatter-rbac-request")}
+          >
+            Request access
+          </button>
+          <button
+            type="button"
+            onClick={() => openHosted("/admin/rbac", "valoride-graymatter-rbac-admin")}
+          >
+            Open admin RBAC
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (grayMatterSession?.status === "unavailable") {
+    return (
+      <div className="capability-command-center__quota" role="alert">
+        <div className="capability-command-center__quota-copy">
+          <FaCreditCard aria-hidden="true" />
+          <span>GrayMatter is unavailable. Open diagnostics and retry setup.</span>
+        </div>
+        <div className="capability-command-center__quota-actions">
+          <button
+            type="button"
+            onClick={() => openHosted("/graymatter/activate", "valoride-graymatter-diagnostics")}
+          >
+            Open diagnostics
+          </button>
+          <button
+            type="button"
+            onClick={() => vscode.postMessage({ type: "webviewDidLaunch" })}
+          >
+            Retry setup
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+};
+
 const CapabilityCommandCenter = () => {
   const state = useExtensionState() as Record<string, any>;
   const grayMatterSession = state.grayMatterSession as
@@ -334,6 +425,31 @@ const CapabilityCommandCenter = () => {
           latestCommand={latestCommand}
           state={state}
         />
+      ) : null}
+      {grayMatterSession?.status !== "quota" ? (
+        <GrayMatterRecoveryActions grayMatterSession={grayMatterSession} state={state} />
+      ) : null}
+      {mcp.tone === "warn" ? (
+        <div className="capability-command-center__quota" role="status">
+          <div className="capability-command-center__quota-copy">
+            <FaPlug aria-hidden="true" />
+            <span>MCP connectivity needs attention. Retry discovery or open setup.</span>
+          </div>
+          <div className="capability-command-center__quota-actions">
+            <button
+              type="button"
+              onClick={() => vscode.postMessage({ type: "fetchLatestMcpServersFromHub" })}
+            >
+              Retry discovery
+            </button>
+            <button
+              type="button"
+              onClick={() => vscode.postMessage({ type: "mcpButtonClicked", tab: "installed" })}
+            >
+              Open MCP setup
+            </button>
+          </div>
+        </div>
       ) : null}
     </section>
   );


### PR DESCRIPTION
## Summary\n- add guided recovery CTAs for GrayMatter unauthenticated, forbidden, and unavailable states\n- add MCP disconnected recovery actions (retry discovery + open setup)\n- extend command center unit tests for new CTA payloads\n\n## Testing\n- npx vitest run src/components/agentic/CapabilityCommandCenter.test.tsx *(fails in this environment: missing vitest package in shared node_modules)*