### PR TITLE
feat(marketplace): purchase review flow and trust signals (#2977)

### DIFF
--- a/src/views/MonetizedServicesMarketplace.css
+++ b/src/views/MonetizedServicesMarketplace.css
@@ -294,6 +294,45 @@
   margin-bottom: 12px;
 }
 
+.trust-signal-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.trust-chip {
+  padding: 4px 8px;
+  border: 1px solid rgba(76, 175, 80, 0.35);
+  border-radius: 999px;
+  background: rgba(76, 175, 80, 0.12);
+  color: #9be89f;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.spend-estimate {
+  display: grid;
+  gap: 2px;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 193, 7, 0.25);
+  border-radius: 8px;
+  background: rgba(255, 193, 7, 0.08);
+  margin-bottom: 12px;
+}
+
+.spend-estimate span {
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.spend-estimate strong {
+  color: #ffe08a;
+  font-size: 13px;
+}
+
 .card-actions {
   display: flex;
   gap: 8px;
@@ -586,6 +625,33 @@
   color: rgba(255, 255, 255, 0.75);
   display: grid;
   gap: 6px;
+}
+
+.modal-trust-panel {
+  margin: 14px 0;
+  padding: 12px;
+  background: rgba(100, 200, 255, 0.06);
+  border: 1px solid rgba(100, 200, 255, 0.18);
+  border-radius: 8px;
+}
+
+.modal-trust-panel h3 {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+}
+
+.modal-trust-panel ul {
+  margin: 0 0 8px 18px;
+  padding: 0;
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 13px;
+}
+
+.modal-trust-panel p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.64);
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .service-modal select {

--- a/src/views/MonetizedServicesMarketplace.test.tsx
+++ b/src/views/MonetizedServicesMarketplace.test.tsx
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import { JSDOM } from "jsdom";
-import type { ManagedMcpService } from "@thorapi/services/monetization/ServiceMonetizationService";
+import type {
+  ManagedMcpService,
+  SubscriptionType,
+} from "@thorapi/services/monetization/ServiceMonetizationService";
 
 const dom = new JSDOM("<!doctype html><html><body></body></html>", {
   url: "http://localhost/",
@@ -15,11 +18,18 @@ jest.mock("./MonetizedServicesMarketplace.css", () => ({}));
 
 jest.mock("@thorapi/services/monetization/ServiceMonetizationService", () => ({
   getMarketplaceServices: jest.fn(),
+  getService: jest.fn(),
   subscribeToService: jest.fn(),
 }));
 
 const React = require("react");
-const { act, render, screen, waitFor } = require("@testing-library/react");
+const {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} = require("@testing-library/react");
 require("@testing-library/jest-dom");
 
 const {
@@ -27,6 +37,8 @@ const {
 } = require("./MonetizedServicesMarketplace");
 const {
   getMarketplaceServices,
+  getService,
+  subscribeToService,
 } = require("@thorapi/services/monetization/ServiceMonetizationService");
 const {
   MONETIZATION_PRICING_UPDATED_EVENT,
@@ -36,20 +48,33 @@ const getMarketplaceServicesMock =
   getMarketplaceServices as jest.MockedFunction<
     () => Promise<ManagedMcpService[]>
   >;
+const getServiceMock = getService as jest.MockedFunction<
+  (serviceId: string) => Promise<ManagedMcpService>
+>;
+const subscribeToServiceMock = subscribeToService as jest.MockedFunction<
+  (serviceId: string, subscriptionType?: SubscriptionType) => Promise<unknown>
+>;
 
 function service(overrides: Partial<ManagedMcpService> = {}) {
   return {
     id: "svc-123",
     applicationId: "app-123",
     name: "Revenue Bot",
+    description: "Finds expansion opportunities",
     createdBy: "creator-1",
     status: "MONETIZED",
     pricingModel: "PER_CALL",
     costPerCall: 5,
+    tierName: "PRO",
     hideFromMarketplace: false,
     isMonetized: true,
     createdAt: "2026-05-21T00:00:00.000Z",
     updatedAt: "2026-05-21T00:00:00.000Z",
+    creatorName: "Aster Labs",
+    creatorVerified: true,
+    invocationCount: 120,
+    successRate: 0.96,
+    rating: 4.7,
     ...overrides,
   } satisfies ManagedMcpService;
 }
@@ -58,6 +83,7 @@ describe("MonetizedServicesMarketplace", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     document.body.innerHTML = "";
+    (global as any).alert = jest.fn();
   });
 
   it("refreshes marketplace pricing after a creator pricing save event", async () => {
@@ -93,5 +119,41 @@ describe("MonetizedServicesMarketplace", () => {
       expect(getMarketplaceServicesMock).toHaveBeenCalledTimes(2),
     );
     expect(await screen.findByText("9")).toBeInTheDocument();
+  });
+
+  it("opens a purchase review sheet before subscribing and avoids browser alerts", async () => {
+    const marketplaceService = service({
+      id: "svc-revenue",
+      applicationId: "app-revenue",
+      name: "Revenue MCP",
+    });
+    getMarketplaceServicesMock
+      .mockResolvedValueOnce([marketplaceService])
+      .mockResolvedValueOnce([marketplaceService]);
+    getServiceMock.mockResolvedValue(marketplaceService);
+    subscribeToServiceMock.mockResolvedValue({ id: "sub-1" });
+
+    render(<MonetizedServicesMarketplace />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /review & subscribe/i }),
+    );
+
+    expect(await screen.findByText(/purchase review/i)).toBeInTheDocument();
+    expect(await screen.findByText(/trust posture/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Aster Labs/i).length).toBeGreaterThan(0);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /confirm subscription/i }),
+    );
+
+    await waitFor(() =>
+      expect(subscribeToServiceMock).toHaveBeenCalledWith(
+        "svc-revenue",
+        "PAY_AS_YOU_GO",
+      ),
+    );
+    await screen.findByText(/subscription activated/i);
+    expect((global as any).alert).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- replace alert-only subscribe flow with a purchase review modal
- surface creator identity, trust signals, and estimated spend before subscribe
- switch popularity sort from recency-only to quality/usage weighted score
- add focused tests for presentation helpers and purchase review subscribe flow

## Testing
- npx jest src/views/marketplacePresentation.test.ts src/views/MonetizedServicesMarketplace.test.tsx --runInBand *(fails locally: Cannot find module 'esbuild' in this worktree)*
