### PR TITLE
[P0][Security] Redact URI auth callback diagnostics

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,7 @@ import {
   registerGrayMatterCommands,
 } from "./commands/graymatter/graymatterCommands";
 import { SelectedLlmDetails } from "@shared/llm";
+import { buildAuthCallbackDiagnostics } from "./utils/authCallback";
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -543,16 +544,11 @@ export function activate(context: vscode.ExtensionContext) {
 
   // URI Handler
   const handleUri = async (uri: vscode.Uri) => {
-    console.log("URI Handler called with:", {
-      path: uri.path,
-      query: uri.query,
-      scheme: uri.scheme,
-    });
-
     const path = uri.path;
     // Guard against missing query to avoid calling replace on undefined
     const rawQuery = uri.query || "";
     const query = new URLSearchParams(rawQuery.replace(/\+/g, "%2B"));
+    Logger.log("URI callback received", buildAuthCallbackDiagnostics(path, query));
     const visibleWebview = WebviewProvider.getVisibleInstance();
     if (!visibleWebview) {
       return;
@@ -566,23 +562,17 @@ export function activate(context: vscode.ExtensionContext) {
         break;
       }
       case "/auth": {
-        const token = query.get("token");
         const state = query.get("state");
-        const apiKey = query.get("apiKey");
-        const authenticatedPrincipal = query.get("authenticatedPrincipal");
-
-        console.log("Auth callback received:", {
-          token: token,
-          state: state,
-          apiKey: apiKey,
-          authenticatedPrincipal: authenticatedPrincipal,
-        });
 
         // Validate state parameter
         if (!(await visibleWebview?.controller.validateAuthState(state))) {
           vscode.window.showErrorMessage("Invalid auth state");
           return;
         }
+
+        const token = query.get("token");
+        const apiKey = query.get("apiKey");
+        const authenticatedPrincipal = query.get("authenticatedPrincipal");
 
         if (token && apiKey) {
           let parsedUser;
@@ -591,7 +581,7 @@ export function activate(context: vscode.ExtensionContext) {
               ? JSON.parse(decodeURIComponent(authenticatedPrincipal))
               : undefined;
           } catch (error) {
-            console.warn("Failed to parse authenticatedPrincipal:", error);
+            Logger.log("Failed to parse auth callback principal payload");
           }
 
           // Use StartupAuthService to handle login persistently

--- a/src/test/suite/authCallback.test.ts
+++ b/src/test/suite/authCallback.test.ts
@@ -1,0 +1,20 @@
+import { expect } from "chai";
+import { buildAuthCallbackDiagnostics } from "../../utils/authCallback";
+
+describe("auth callback diagnostics", () => {
+  it("returns only booleans and never raw secret values", () => {
+    const query = new URLSearchParams(
+      "state=s1&token=jwt-secret&apiKey=api-secret&authenticatedPrincipal=%7B%22email%22%3A%22u%40x.com%22%7D",
+    );
+    const diagnostics = buildAuthCallbackDiagnostics("/auth", query);
+
+    expect(diagnostics.path).to.equal("/auth");
+    expect(diagnostics.hasState).to.equal(true);
+    expect(diagnostics.hasToken).to.equal(true);
+    expect(diagnostics.hasApiKey).to.equal(true);
+    expect(diagnostics.hasAuthenticatedPrincipal).to.equal(true);
+    expect(JSON.stringify(diagnostics)).to.not.include("jwt-secret");
+    expect(JSON.stringify(diagnostics)).to.not.include("api-secret");
+    expect(JSON.stringify(diagnostics)).to.not.include("u@x.com");
+  });
+});

--- a/src/utils/authCallback.ts
+++ b/src/utils/authCallback.ts
@@ -1,0 +1,13 @@
+export function buildAuthCallbackDiagnostics(
+  path: string,
+  query: URLSearchParams,
+): Record<string, boolean | string> {
+  return {
+    path,
+    hasState: Boolean(query.get("state")),
+    hasCode: Boolean(query.get("code")),
+    hasToken: Boolean(query.get("token")),
+    hasApiKey: Boolean(query.get("apiKey")),
+    hasAuthenticatedPrincipal: Boolean(query.get("authenticatedPrincipal")),
+  };
+}


### PR DESCRIPTION
## Summary
- remove raw URI callback logging that exposed query contents
- log only boolean callback diagnostics (hasState/hasCode/hasToken/hasApiKey/hasAuthenticatedPrincipal)
- validate auth state before reading token/apiKey/principal query values
- add unit test asserting diagnostic payload never contains raw token/apiKey/principal data

## Validation
- 
> valoride-dev@3.20.839 compile-tests
> tsc -p ./tsconfig.test.json --outDir out --pretty false

src/services/communication/RemoteCodingSessionRegistry.ts(64,5): error TS1109: Expression expected.
src/services/communication/RemoteCodingSessionRegistry.ts(66,5): error TS1068: Unexpected token. A constructor, method, accessor, or property was expected.
src/services/communication/RemoteCodingSessionRegistry.ts(72,3): error TS1128: Declaration or statement expected.
src/services/communication/RemoteCodingSessionRegistry.ts(74,9): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(74,31): error TS1011: An element access expression should take an argument.
src/services/communication/RemoteCodingSessionRegistry.ts(74,33): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(82,16): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(82,25): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(82,59): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(90,22): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(90,35): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(90,57): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(90,59): error TS1434: Unexpected keyword or identifier.
src/services/communication/RemoteCodingSessionRegistry.ts(101,14): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(102,8): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(103,8): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(104,4): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(104,6): error TS1434: Unexpected keyword or identifier.
src/services/communication/RemoteCodingSessionRegistry.ts(112,14): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(113,13): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(114,8): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(115,4): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(115,6): error TS1434: Unexpected keyword or identifier.
src/services/communication/RemoteCodingSessionRegistry.ts(123,14): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(124,11): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(128,8): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(129,4): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(129,6): error TS1434: Unexpected keyword or identifier.
src/services/communication/RemoteCodingSessionRegistry.ts(138,14): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(139,11): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(140,8): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(141,4): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(141,6): error TS1434: Unexpected keyword or identifier.
src/services/communication/RemoteCodingSessionRegistry.ts(150,29): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(150,51): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(150,73): error TS1011: An element access expression should take an argument.
src/services/communication/RemoteCodingSessionRegistry.ts(150,75): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(168,3): error TS1128: Declaration or statement expected.
src/services/communication/RemoteCodingSessionRegistry.ts(168,35): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(168,44): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(168,46): error TS1434: Unexpected keyword or identifier.
src/services/communication/RemoteCodingSessionRegistry.ts(176,3): error TS1128: Declaration or statement expected.
src/services/communication/RemoteCodingSessionRegistry.ts(176,27): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(176,49): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(176,51): error TS1434: Unexpected keyword or identifier.
src/services/communication/RemoteCodingSessionRegistry.ts(180,3): error TS1128: Declaration or statement expected.
src/services/communication/RemoteCodingSessionRegistry.ts(180,27): error TS1005: ',' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(180,49): error TS1005: ';' expected.
src/services/communication/RemoteCodingSessionRegistry.ts(180,51): error TS1434: Unexpected keyword or identifier.
src/services/communication/RemoteCodingSessionRegistry.ts(187,1): error TS1128: Declaration or statement expected. *(currently blocked by pre-existing syntax errors in  on rc-5)*
