### PR TITLE
feat: convert Swarm quota warnings into billing recovery

### DIFF
--- a/webview-ui/src/components/SwarmPanel/SwarmPanel.test.tsx
+++ b/webview-ui/src/components/SwarmPanel/SwarmPanel.test.tsx
@@ -25,12 +25,15 @@ function mockFetchWithBilling(status: any) {
 
 describe("SwarmPanel billing conversion flow", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    vi.stubGlobal("open", vi.fn());
+    (window as any).__valkyr_organizationId = "org-123";
+    (window as any).__valoride_workspaceId = "workspace-456";
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.unstubAllGlobals();
+    delete (window as any).__valkyr_organizationId;
+    delete (window as any).__valoride_workspaceId;
   });
 
   it("opens upgrade flow from Upgrade Quota", async () => {
@@ -47,6 +50,36 @@ describe("SwarmPanel billing conversion flow", () => {
     expect(screen.getByText("Upgrade quota")).toBeInTheDocument();
   });
 
+  it("starts checkout with organization and workspace attribution", async () => {
+    mockFetchWithBilling({
+      ...activeBilling,
+      activeAgentCount: 10,
+      remainingQuota: 0,
+    });
+    render(<SwarmPanel />);
+
+    fireEvent.click(screen.getByText("💰 Billing"));
+    await waitFor(() => {
+      expect(screen.getByText("💳 Upgrade Quota")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("💳 Upgrade Quota"));
+    fireEvent.click(screen.getByText("Start checkout"));
+
+    expect(window.open).toHaveBeenCalledWith(
+      expect.stringContaining("source=valoride-swarm-quota"),
+      "_blank",
+    );
+    expect(window.open).toHaveBeenCalledWith(
+      expect.stringContaining("organizationId=org-123"),
+      "_blank",
+    );
+    expect(window.open).toHaveBeenCalledWith(
+      expect.stringContaining("workspaceId=workspace-456"),
+      "_blank",
+    );
+  });
+
   it("opens billing history from Billing History", async () => {
     mockFetchWithBilling(activeBilling);
     render(<SwarmPanel />);
@@ -61,7 +94,11 @@ describe("SwarmPanel billing conversion flow", () => {
   });
 
   it("shows suspended recovery copy in upgrade flow", async () => {
-    mockFetchWithBilling({ ...activeBilling, billingStatus: "SUSPENDED", remainingQuota: 0 });
+    mockFetchWithBilling({
+      ...activeBilling,
+      billingStatus: "SUSPENDED",
+      remainingQuota: 0,
+    });
     render(<SwarmPanel />);
 
     fireEvent.click(screen.getByText("💰 Billing"));
@@ -71,7 +108,42 @@ describe("SwarmPanel billing conversion flow", () => {
 
     fireEvent.click(screen.getByText("💳 Upgrade Quota"));
     expect(
-      screen.getByText(/Billing is suspended\. Update payment method/i),
+      screen.getByText(
+        /Billing is suspended\. Update payment method, buy credits/i,
+      ),
     ).toBeInTheDocument();
+    expect(screen.getByText("Update payment method")).toBeInTheDocument();
+    expect(screen.getByText("Buy credits")).toBeInTheDocument();
+    expect(screen.getByText("Contact admin")).toBeInTheDocument();
+    expect(screen.getByText("Contact support")).toBeInTheDocument();
+  });
+
+  it("tracks quota warning analytics once", async () => {
+    const analyticsSpy = vi.fn();
+    window.addEventListener("valoride-analytics", analyticsSpy);
+    mockFetchWithBilling({
+      ...activeBilling,
+      activeAgentCount: 8,
+      quotaAgents: 10,
+    });
+
+    render(<SwarmPanel />);
+    await waitFor(() => {
+      expect(analyticsSpy).toHaveBeenCalled();
+    });
+
+    const warningEvents = analyticsSpy.mock.calls.filter((call) => {
+      const event = call[0] as CustomEvent;
+      return event.detail.eventName === "valoride.quota_warning_seen";
+    });
+    expect(warningEvents).toHaveLength(1);
+    expect(warningEvents[0][0].detail).toEqual(
+      expect.objectContaining({
+        organizationId: "org-123",
+        workspaceId: "workspace-456",
+      }),
+    );
+
+    window.removeEventListener("valoride-analytics", analyticsSpy);
   });
 });

--- a/webview-ui/src/components/SwarmPanel/SwarmPanel.tsx
+++ b/webview-ui/src/components/SwarmPanel/SwarmPanel.tsx
@@ -40,9 +40,9 @@ type BillingStatus = {
 
 type BillingHistoryEntry = {
   id: string;
-  kind: "CHARGE" | "USAGE" | "PURCHASE";
+  kind: "CHARGE" | "USAGE" | "PURCHASE" | "INVOICE";
   amount: number;
-  status: "SUCCEEDED" | "FAILED";
+  status: "SUCCEEDED" | "FAILED" | "PENDING";
   createdAt: string;
   detail: string;
 };
@@ -171,6 +171,36 @@ const fetchBillingStatus = async (
   }
 };
 
+const buildBillingUrl = (
+  path:
+    | "checkout"
+    | "payment-method"
+    | "credits"
+    | "history"
+    | "admin-handoff"
+    | "support",
+  billingStatus: BillingStatus | null,
+): string => {
+  const origin =
+    (window as any).__valkyr_billingBaseUrl || "https://valkyrlabs.com/billing";
+  const url = new URL(`${origin}/${path}`);
+  const organizationId = getOrganizationId();
+  const workspaceId =
+    (window as any).__valoride_workspaceId || "workspace-default";
+  url.searchParams.set("source", "valoride-swarm-quota");
+  url.searchParams.set("organizationId", organizationId);
+  url.searchParams.set("workspaceId", workspaceId);
+  if (billingStatus) {
+    url.searchParams.set("billingStatus", billingStatus.billingStatus);
+    url.searchParams.set(
+      "activeAgents",
+      String(billingStatus.activeAgentCount),
+    );
+    url.searchParams.set("quotaAgents", String(billingStatus.quotaAgents));
+  }
+  return url.toString();
+};
+
 /**
  * Parse HTTP error response and generate user-friendly message
  */
@@ -233,6 +263,7 @@ export const SwarmPanel: React.FC = () => {
   const [alerts, setAlerts] = useState<ErrorAlert[]>([]);
   const [showUpgradeFlow, setShowUpgradeFlow] = useState(false);
   const [showBillingHistory, setShowBillingHistory] = useState(false);
+  const quotaWarningTrackedRef = React.useRef(false);
 
   // Get userId/senderId from window or localStorage
   const getSenderId = useCallback(() => {
@@ -259,6 +290,8 @@ export const SwarmPanel: React.FC = () => {
           detail: {
             eventName,
             organizationId: getOrganizationId(),
+            workspaceId:
+              (window as any).__valoride_workspaceId || "workspace-default",
             timestamp: Date.now(),
           },
         }),
@@ -359,6 +392,10 @@ export const SwarmPanel: React.FC = () => {
           status &&
           status.activeAgentCount >= status.quotaAgents * 0.8
         ) {
+          if (!quotaWarningTrackedRef.current) {
+            trackBillingEvent("valoride.quota_warning_seen");
+            quotaWarningTrackedRef.current = true;
+          }
           addAlert(
             "warning",
             `⚠️ Quota warning: Using ${Math.round((status.activeAgentCount / status.quotaAgents) * 100)}% of your agent limit.`,
@@ -372,7 +409,7 @@ export const SwarmPanel: React.FC = () => {
     loadBilling();
     const billingInterval = setInterval(loadBilling, 30000); // Refresh every 30s
     return () => clearInterval(billingInterval);
-  }, [addAlert]);
+  }, [addAlert, trackBillingEvent]);
 
   // Load chat history when agent is selected + auto-refresh every 5 seconds
   useEffect(() => {
@@ -529,7 +566,9 @@ export const SwarmPanel: React.FC = () => {
   });
 
   const usagePercent = billingStatus
-    ? Math.round((billingStatus.activeAgentCount / billingStatus.quotaAgents) * 100)
+    ? Math.round(
+        (billingStatus.activeAgentCount / billingStatus.quotaAgents) * 100,
+      )
     : 0;
 
   const billingHistory: BillingHistoryEntry[] = [
@@ -548,6 +587,18 @@ export const SwarmPanel: React.FC = () => {
       status: "SUCCEEDED",
       createdAt: new Date(Date.now() - 86400000).toISOString(),
       detail: "Agent instantiation usage",
+    },
+    {
+      id: "invoice-1",
+      kind: "INVOICE",
+      amount: billingStatus?.totalCharges || 0,
+      status:
+        billingStatus?.billingStatus === "SUSPENDED" ? "FAILED" : "PENDING",
+      createdAt: new Date(Date.now() - 172800000).toISOString(),
+      detail:
+        billingStatus?.billingStatus === "SUSPENDED"
+          ? "Payment recovery required"
+          : "Current billing period invoice",
     },
   ];
 
@@ -1109,11 +1160,14 @@ export const SwarmPanel: React.FC = () => {
                   >
                     <strong>Upgrade quota</strong>
                     <p style={{ fontSize: 12, marginTop: 8 }}>
-                      Usage: {billingStatus.activeAgentCount}/{billingStatus.quotaAgents} ({usagePercent}%).
+                      Usage: {billingStatus.activeAgentCount}/
+                      {billingStatus.quotaAgents} ({usagePercent}%).
                     </p>
                     {billingStatus.billingStatus === "SUSPENDED" ? (
                       <p style={{ fontSize: 12, color: "#b71c1c" }}>
-                        Billing is suspended. Update payment method or contact your workspace admin.
+                        Billing is suspended. Update payment method, buy
+                        credits, contact your workspace admin, or contact
+                        support.
                       </p>
                     ) : null}
                     <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
@@ -1121,13 +1175,61 @@ export const SwarmPanel: React.FC = () => {
                         onClick={() => {
                           trackBillingEvent("valoride.checkout_started");
                           window.open(
-                            `https://valkyrlabs.com/billing/checkout?organizationId=${encodeURIComponent(getOrganizationId())}`,
+                            buildBillingUrl("checkout", billingStatus),
                             "_blank",
                           );
                         }}
                         style={{ padding: "6px 10px", cursor: "pointer" }}
                       >
                         Start checkout
+                      </button>
+                      <button
+                        onClick={() => {
+                          trackBillingEvent("valoride.billing_recovered");
+                          window.open(
+                            buildBillingUrl("payment-method", billingStatus),
+                            "_blank",
+                          );
+                        }}
+                        style={{ padding: "6px 10px", cursor: "pointer" }}
+                      >
+                        Update payment method
+                      </button>
+                      <button
+                        onClick={() => {
+                          trackBillingEvent("valoride.checkout_started");
+                          window.open(
+                            buildBillingUrl("credits", billingStatus),
+                            "_blank",
+                          );
+                        }}
+                        style={{ padding: "6px 10px", cursor: "pointer" }}
+                      >
+                        Buy credits
+                      </button>
+                      <button
+                        onClick={() => {
+                          trackBillingEvent("valoride.billing_recovered");
+                          window.open(
+                            buildBillingUrl("admin-handoff", billingStatus),
+                            "_blank",
+                          );
+                        }}
+                        style={{ padding: "6px 10px", cursor: "pointer" }}
+                      >
+                        Contact admin
+                      </button>
+                      <button
+                        onClick={() => {
+                          trackBillingEvent("valoride.billing_recovered");
+                          window.open(
+                            buildBillingUrl("support", billingStatus),
+                            "_blank",
+                          );
+                        }}
+                        style={{ padding: "6px 10px", cursor: "pointer" }}
+                      >
+                        Contact support
                       </button>
                       <button
                         onClick={async () => {
@@ -1161,17 +1263,38 @@ export const SwarmPanel: React.FC = () => {
                   >
                     <strong>Billing history</strong>
                     <div style={{ marginTop: 8, fontSize: 12 }}>
-                      {billingHistory.map((entry) => (
-                        <div key={entry.id} style={{ marginBottom: 8 }}>
-                          <div>
-                            {entry.kind} • ${entry.amount.toFixed(2)} • {entry.status}
+                      {billingHistory.length > 0 ? (
+                        billingHistory.map((entry) => (
+                          <div key={entry.id} style={{ marginBottom: 8 }}>
+                            <div>
+                              {entry.kind} • ${entry.amount.toFixed(2)} •{" "}
+                              {entry.status}
+                            </div>
+                            <div style={{ color: "#666" }}>
+                              {entry.detail} •{" "}
+                              {new Date(entry.createdAt).toLocaleString()}
+                            </div>
                           </div>
-                          <div style={{ color: "#666" }}>
-                            {entry.detail} • {new Date(entry.createdAt).toLocaleString()}
-                          </div>
-                        </div>
-                      ))}
+                        ))
+                      ) : (
+                        <p>No billing activity yet.</p>
+                      )}
                     </div>
+                    <button
+                      onClick={() =>
+                        window.open(
+                          buildBillingUrl("history", billingStatus),
+                          "_blank",
+                        )
+                      }
+                      style={{
+                        padding: "6px 10px",
+                        cursor: "pointer",
+                        marginRight: 8,
+                      }}
+                    >
+                      Open full history
+                    </button>
                     <button
                       onClick={() => setShowBillingHistory(false)}
                       style={{ padding: "6px 10px", cursor: "pointer" }}


### PR DESCRIPTION
## Summary
- add attributed billing URLs for Swarm quota checkout, credits, payment-method recovery, history, admin handoff, and support
- track quota warning analytics once with organization/workspace context
- expand SwarmPanel billing tests for checkout attribution, suspended recovery actions, and analytics

## Validation
- npm --prefix webview-ui test -- SwarmPanel.test.tsx
- npm --prefix webview-ui run build -- --mode test (fails before this change because root-level dependencies are missing in the clean worktree: react-redux, @reduxjs/toolkit, react-bootstrap, @bufbuild/protobuf/wire, and related repo-wide imports)

Closes ValkyrLabs/ValkyrAI#2869