### PR TITLE
[P0][#2949] Enforce ValorIDE VSIX runtime allowlist

### DIFF
--- a/scripts/audit-vsix-package.mjs
+++ b/scripts/audit-vsix-package.mjs
@@ -9,11 +9,25 @@ const DEFAULT_MAX_FILE_COUNT = 15000;
 const FORBIDDEN_RULES = [
   { id: 'worktrees', pattern: /(^|\/)\.worktrees(\/|$)/, message: 'workspace worktrees must never ship in the VSIX' },
   { id: 'node_modules', pattern: /(^|\/)node_modules(\/|$)/, message: 'dependency trees must be bundled into dist, not packaged raw' },
+  { id: 'source_tree', pattern: /^extension\/(src|test|tests|__tests__)(\/|$)/, message: 'source and test trees must not ship in marketplace packages' },
+  { id: 'docs_tree', pattern: /^extension\/(docs|samples|templates|evals|system-prompts-and-models-of-ai-tools)(\/|$)/, message: 'docs, samples, templates, and eval fixtures are not runtime assets' },
+  { id: 'webview_source', pattern: /^extension\/webview-ui\/(src|public|node_modules|build)(\/|$)/, message: 'webview source/build trees must ship only through dist/webview' },
+  { id: 'package_lock', pattern: /(^|\/)(yarn\.lock|package-lock\.json|pnpm-lock\.yaml|npm-shrinkwrap\.json)$/i, message: 'package manager lockfiles are release inputs, not VSIX runtime assets' },
+  { id: 'dev_config', pattern: /^extension\/(tsconfig[^/]*\.json|eslint\.config\.[cm]?js|jest\.config\.[cm]?js|vite\.config\.ts|esbuild\.js)$/i, message: 'development config must not ship in marketplace packages' },
   { id: 'source_map', pattern: /\.map$/i, message: 'source maps are dev-only and bloat marketplace uploads' },
   { id: 'duplicate_webview_build', pattern: /(^|\/)webview-ui\/build(\/|$)/, message: 'webview build output should ship only from dist/webview' },
   { id: 'native_swc_binary', pattern: /(^|\/)@swc\/core-[^/]+(\/|$)/, message: 'native SWC binaries are development tooling, not runtime extension assets' },
   { id: 'native_esbuild_binary', pattern: /(^|\/)@esbuild\/[^/]+(\/|$)/, message: 'native esbuild binaries are development tooling, not runtime extension assets' },
   { id: 'vsix_inside_vsix', pattern: /\.vsix$/i, message: 'previous VSIX artifacts must never be nested in a release package' },
+];
+
+const ALLOWED_RUNTIME_ENTRY_PATTERNS = [
+  /^\[Content_Types\]\.xml$/,
+  /^extension\.vsixmanifest$/,
+  /^extension\/(package\.json|README\.md|LICENSE)$/,
+  /^extension\/dist\//,
+  /^extension\/assets\/icons\//,
+  /^extension\/assets\/valorIde\.acorn$/,
 ];
 
 export function parseUnzipListing(listing) {
@@ -35,12 +49,16 @@ export function auditEntries(entries, options = {}) {
   const archiveBytes = Number(options.archiveBytes ?? 0);
   const totalUncompressedBytes = entries.reduce((sum, entry) => sum + entry.size, 0);
   const forbiddenMatches = [];
+  const unexpectedRuntimeEntries = [];
 
   for (const entry of entries) {
     for (const rule of FORBIDDEN_RULES) {
       if (rule.pattern.test(entry.name)) {
         forbiddenMatches.push({ rule: rule.id, message: rule.message, path: entry.name, size: entry.size });
       }
+    }
+    if (!ALLOWED_RUNTIME_ENTRY_PATTERNS.some((pattern) => pattern.test(entry.name))) {
+      unexpectedRuntimeEntries.push({ path: entry.name, size: entry.size });
     }
   }
 
@@ -54,6 +72,9 @@ export function auditEntries(entries, options = {}) {
   if (forbiddenMatches.length > 0) {
     failures.push(`${forbiddenMatches.length} forbidden package entries detected`);
   }
+  if (unexpectedRuntimeEntries.length > 0) {
+    failures.push(`${unexpectedRuntimeEntries.length} entries outside the runtime package allowlist detected`);
+  }
 
   return {
     ok: failures.length === 0,
@@ -63,6 +84,7 @@ export function auditEntries(entries, options = {}) {
     fileCount: entries.length,
     failures,
     forbiddenMatches,
+    unexpectedRuntimeEntries,
     largestFiles: [...entries].sort((a, b) => b.size - a.size).slice(0, 50),
   };
 }
@@ -84,6 +106,11 @@ export function formatMarkdownReport(report, vsixPath = 'unknown') {
     '## Forbidden entries',
     ...(report.forbiddenMatches.length
       ? report.forbiddenMatches.slice(0, 100).map((entry) => `- ${entry.rule}: ${entry.path} (${entry.size} bytes)`)
+      : ['- none']),
+    '',
+    '## Unexpected runtime entries',
+    ...(report.unexpectedRuntimeEntries.length
+      ? report.unexpectedRuntimeEntries.slice(0, 100).map((entry) => `- ${entry.path} (${entry.size} bytes)`)
       : ['- none']),
     '',
     '## Largest files',

--- a/scripts/audit-vsix-package.test.mjs
+++ b/scripts/audit-vsix-package.test.mjs
@@ -32,21 +32,61 @@ test('auditEntries fails packages that exceed budgets', () => {
 test('auditEntries blocks known VSIX bloat sources', () => {
   const report = auditEntries([
     { size: 1, name: 'extension/.worktrees/feature/package.json' },
+    { size: 1, name: 'extension/src/extension.ts' },
+    { size: 1, name: 'extension/docs/release-notes.md' },
+    { size: 1, name: 'extension/webview-ui/src/main.tsx' },
+    { size: 1, name: 'extension/yarn.lock' },
+    { size: 1, name: 'extension/tsconfig.json' },
     { size: 1, name: 'extension/webview-ui/build/assets/index.js' },
     { size: 1, name: 'extension/dist/extension.js.map' },
     { size: 1, name: 'extension/node_modules/@esbuild/darwin-arm64/bin/esbuild' },
     { size: 1, name: 'extension/node_modules/@swc/core-darwin-arm64/swc.darwin-arm64.node' },
-  ], { archiveBytes: 5, maxArchiveBytes: 1000, maxFileCount: 20 });
+  ], { archiveBytes: 10, maxArchiveBytes: 1000, maxFileCount: 20 });
 
   assert.equal(report.ok, false);
   assert.deepEqual(report.forbiddenMatches.map((match) => match.rule).sort(), [
+    'dev_config',
+    'docs_tree',
     'duplicate_webview_build',
     'native_esbuild_binary',
     'native_swc_binary',
     'node_modules',
     'node_modules',
+    'package_lock',
     'source_map',
+    'source_tree',
+    'webview_source',
+    'webview_source',
     'worktrees',
+  ]);
+});
+
+test('auditEntries enforces the runtime package allowlist', () => {
+  const passing = auditEntries([
+    { size: 10, name: '[Content_Types].xml' },
+    { size: 10, name: 'extension.vsixmanifest' },
+    { size: 20, name: 'extension/package.json' },
+    { size: 20, name: 'extension/README.md' },
+    { size: 20, name: 'extension/LICENSE' },
+    { size: 200, name: 'extension/dist/extension.js' },
+    { size: 200, name: 'extension/dist/webview/assets/index.js' },
+    { size: 50, name: 'extension/assets/icons/icon.png' },
+    { size: 50, name: 'extension/assets/valorIde.acorn' },
+  ], { archiveBytes: 550, maxArchiveBytes: 1000, maxFileCount: 20 });
+
+  assert.equal(passing.ok, true);
+  assert.deepEqual(passing.unexpectedRuntimeEntries, []);
+
+  const failing = auditEntries([
+    { size: 10, name: 'extension/CHANGELOG.md' },
+    { size: 10, name: 'extension/assets/docs/demo.gif' },
+  ], { archiveBytes: 20, maxArchiveBytes: 1000, maxFileCount: 20 });
+
+  assert.equal(failing.ok, false);
+  assert.match(failing.failures.join('\n'), /entries outside the runtime package allowlist/);
+  assert.deepEqual(failing.unexpectedRuntimeEntries.map((entry) => entry.path), [
+    'extension/CHANGELOG.md',
+    'extension/assets/docs/demo.gif',
   ]);
 });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -567,8 +567,7 @@ export function activate(context: vscode.ExtensionContext) {
     const rawQuery = uri.query || "";
     const query = new URLSearchParams(rawQuery.replace(/\+/g, "%2B"));
     Logger.log(
-      "URI callback received",
-      buildAuthCallbackDiagnostics(path, query),
+      `URI callback received: ${JSON.stringify(buildAuthCallbackDiagnostics(path, query))}`,
     );
     const visibleWebview = WebviewProvider.getVisibleInstance();
     if (!visibleWebview) {


### PR DESCRIPTION
Links ValkyrLabs/ValkyrAI#2949

## Scope
- Strengthens the existing VSIX audit to block source/test trees, docs/sample/template/eval assets, webview source/build trees, package lockfiles, and dev config from packaged releases.
- Adds a strict runtime allowlist for expected VSIX entries: manifest metadata, package metadata, bundled dist output, icons, and the runtime acorn asset.
- Extends node:test coverage for forbidden bloat sources and allowlist pass/fail behavior.

## Verification
- node --test scripts/audit-vsix-package.test.mjs
- git diff --check