### PR TITLE
[P0][#2863] Respect returning-user startup focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -394,6 +394,12 @@
           "markdownDescription": "Base URL used for ValkyrAI API calls (synced across machines).",
           "scope": "application"
         },
+        "valoride.revealOnStartup": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Reveal and focus the ValorIDE sidebar on every startup. ValorIDE still reveals once after first activation and remains available from the Activity Bar, command palette, and status bar.",
+          "scope": "application"
+        },
         "valoride.graymatter.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,10 @@ import {
   initializeLLMPromptService,
   SelectedPrompt,
 } from "./services/llmPromptService";
+import {
+  decideStartupReveal,
+  FIRST_ACTIVATION_REVEAL_STATE_KEY,
+} from "./services/startupRevealPolicy";
 import { getAllExtensionState } from "./core/storage/state";
 import {
   refreshGrayMatterStatus,
@@ -240,9 +244,8 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Initialize ToolRelayService for remote control capabilities
     try {
-      const toolRelayMod = await import(
-        "./services/communication/ToolRelayService"
-      );
+      const toolRelayMod =
+        await import("./services/communication/ToolRelayService");
       const visibleWebview =
         WebviewProvider.getVisibleInstance() || sidebarWebview;
       if (visibleWebview?.controller) {
@@ -283,14 +286,28 @@ export function activate(context: vscode.ExtensionContext) {
     IS_DEV && IS_DEV === "true",
   );
 
-  // Ensure our Activity Bar container is visible, then focus our view
-  // This helps recover if the container was hidden from prior layout changes
-  void vscode.commands.executeCommand(
-    "workbench.view.extension.valoride-activitybar",
-  );
-  // Proactively reveal the sidebar view once after activation
-  // This helps surface the Activity Bar icon if the container was hidden/cached
-  void vscode.commands.executeCommand(`${WebviewProvider.sideBarId}.focus`);
+  const revealDecision = decideStartupReveal({
+    revealOnStartupSetting: vscode.workspace
+      .getConfiguration("valoride")
+      .get<boolean>("revealOnStartup", false),
+    firstActivationRevealCompleted: context.globalState.get<boolean>(
+      FIRST_ACTIVATION_REVEAL_STATE_KEY,
+      false,
+    ),
+  });
+
+  if (revealDecision.shouldReveal) {
+    Logger.log(
+      `Revealing ValorIDE sidebar on activation: ${revealDecision.reason}`,
+    );
+    void vscode.commands.executeCommand(
+      "workbench.view.extension.valoride-activitybar",
+    );
+    void vscode.commands.executeCommand(`${WebviewProvider.sideBarId}.focus`);
+    void context.globalState.update(FIRST_ACTIVATION_REVEAL_STATE_KEY, true);
+  } else {
+    Logger.log("ValorIDE startup reveal skipped for returning user");
+  }
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
@@ -548,7 +565,10 @@ export function activate(context: vscode.ExtensionContext) {
     // Guard against missing query to avoid calling replace on undefined
     const rawQuery = uri.query || "";
     const query = new URLSearchParams(rawQuery.replace(/\+/g, "%2B"));
-    Logger.log("URI callback received", buildAuthCallbackDiagnostics(path, query));
+    Logger.log(
+      "URI callback received",
+      buildAuthCallbackDiagnostics(path, query),
+    );
     const visibleWebview = WebviewProvider.getVisibleInstance();
     if (!visibleWebview) {
       return;

--- a/src/services/startupRevealPolicy.test.ts
+++ b/src/services/startupRevealPolicy.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { decideStartupReveal } from "./startupRevealPolicy";
+
+test("decideStartupReveal reveals on first activation", () => {
+  assert.deepEqual(
+    decideStartupReveal({
+      revealOnStartupSetting: false,
+      firstActivationRevealCompleted: false,
+    }),
+    { shouldReveal: true, reason: "first_activation" },
+  );
+});
+
+test("decideStartupReveal stays quiet for returning users by default", () => {
+  assert.deepEqual(
+    decideStartupReveal({
+      revealOnStartupSetting: false,
+      firstActivationRevealCompleted: true,
+    }),
+    { shouldReveal: false, reason: "returning_user" },
+  );
+});
+
+test("decideStartupReveal honors explicit startup reveal setting", () => {
+  assert.deepEqual(
+    decideStartupReveal({
+      revealOnStartupSetting: true,
+      firstActivationRevealCompleted: true,
+    }),
+    { shouldReveal: true, reason: "explicit_setting" },
+  );
+});

--- a/src/services/startupRevealPolicy.ts
+++ b/src/services/startupRevealPolicy.ts
@@ -1,0 +1,26 @@
+export type StartupRevealDecisionInput = {
+  revealOnStartupSetting?: boolean;
+  firstActivationRevealCompleted?: boolean;
+};
+
+export type StartupRevealDecision = {
+  shouldReveal: boolean;
+  reason: "explicit_setting" | "first_activation" | "returning_user";
+};
+
+export const FIRST_ACTIVATION_REVEAL_STATE_KEY =
+  "valoride.firstActivationRevealCompleted";
+
+export function decideStartupReveal(
+  input: StartupRevealDecisionInput,
+): StartupRevealDecision {
+  if (input.revealOnStartupSetting === true) {
+    return { shouldReveal: true, reason: "explicit_setting" };
+  }
+
+  if (!input.firstActivationRevealCompleted) {
+    return { shouldReveal: true, reason: "first_activation" };
+  }
+
+  return { shouldReveal: false, reason: "returning_user" };
+}


### PR DESCRIPTION
Links ValkyrLabs/ValkyrAI#2863

## Summary
- stop forcing the ValorIDE activity bar/sidebar to focus on every activation for returning users
- keep a one-time first activation reveal and add an explicit `valoride.revealOnStartup` opt-in for users who want the old behavior
- add a small startup reveal policy module with focused tests

## Verification
- npx --yes tsx --test src/services/startupRevealPolicy.test.ts
- git diff --check

## Note
- A narrow `npx --yes tsc --noEmit --skipLibCheck ...` run was blocked by missing Node test type declarations in this worktree (`node:assert/strict`, `node:test`).