### PR TITLE
feat(monetization): require creator terms before pricing

### DIFF
--- a/src/views/MonetizationSettings.css
+++ b/src/views/MonetizationSettings.css
@@ -146,6 +146,46 @@
   font-style: italic;
 }
 
+.earnings-dashboard {
+  background: rgba(76, 175, 80, 0.08);
+  border: 1px solid rgba(76, 175, 80, 0.26);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.earnings-dashboard h4 {
+  margin: 0 0 4px 0;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.earnings-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.earnings-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.earnings-metric span {
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 12px;
+}
+
+.earnings-metric strong {
+  color: #7be495;
+  font-size: 16px;
+}
+
 .button-group {
   display: flex;
   gap: 12px;

--- a/src/views/MonetizationSettings.test.tsx
+++ b/src/views/MonetizationSettings.test.tsx
@@ -15,6 +15,7 @@ jest.mock("./MonetizationSettings.css", () => ({}));
 
 jest.mock("@thorapi/services/monetization/ServiceMonetizationService", () => ({
   enableMonetization: jest.fn(),
+  getTotalEarnings: jest.fn(),
   updatePricing: jest.fn(),
 }));
 
@@ -29,6 +30,8 @@ require("@testing-library/jest-dom");
 
 const { MonetizationSettings } = require("./MonetizationSettings");
 const {
+  enableMonetization,
+  getTotalEarnings,
   updatePricing,
 } = require("@thorapi/services/monetization/ServiceMonetizationService");
 const {
@@ -41,6 +44,16 @@ const updatePricingMock = updatePricing as jest.MockedFunction<
     pricingModel: string,
     costPerCall: number,
   ) => Promise<ManagedMcpService>
+>;
+const enableMonetizationMock = enableMonetization as jest.MockedFunction<
+  (
+    applicationId: string,
+    pricingModel: string,
+    costPerCall: number,
+  ) => Promise<ManagedMcpService>
+>;
+const getTotalEarningsMock = getTotalEarnings as jest.MockedFunction<
+  () => Promise<{ totalAllTimeEarnings: number }>
 >;
 
 function monetizedService(overrides: Partial<ManagedMcpService> = {}) {
@@ -58,6 +71,10 @@ function monetizedService(overrides: Partial<ManagedMcpService> = {}) {
     updatedAt: "2026-05-21T00:00:00.000Z",
     ...overrides,
   } satisfies ManagedMcpService;
+}
+
+function acceptTerms() {
+  fireEvent.click(screen.getByLabelText(/monetization terms/i));
 }
 
 describe("MonetizationSettings", () => {
@@ -84,6 +101,7 @@ describe("MonetizationSettings", () => {
     fireEvent.change(screen.getByLabelText(/cost per call/i), {
       target: { value: "8" },
     });
+    acceptTerms();
     fireEvent.click(screen.getByRole("button", { name: /update pricing/i }));
 
     expect(updatePricingMock).toHaveBeenCalledWith("svc-123", "PER_CALL", 8);
@@ -108,6 +126,7 @@ describe("MonetizationSettings", () => {
       />,
     );
 
+    acceptTerms();
     fireEvent.click(screen.getByRole("button", { name: /update pricing/i }));
 
     await screen.findByText("Unauthorized");
@@ -123,6 +142,7 @@ describe("MonetizationSettings", () => {
       />,
     );
 
+    acceptTerms();
     fireEvent.click(screen.getByRole("button", { name: /update pricing/i }));
 
     await screen.findByText(/no service id was provided/i);
@@ -140,6 +160,7 @@ describe("MonetizationSettings", () => {
     fireEvent.change(screen.getByLabelText(/cost per call/i), {
       target: { value: "0" },
     });
+    acceptTerms();
     fireEvent.click(screen.getByRole("button", { name: /update pricing/i }));
 
     await screen.findByText(/at least 0.1 credits/i);
@@ -162,6 +183,7 @@ describe("MonetizationSettings", () => {
       />,
     );
 
+    acceptTerms();
     fireEvent.click(screen.getByRole("button", { name: /update pricing/i }));
 
     expect(
@@ -175,5 +197,51 @@ describe("MonetizationSettings", () => {
         screen.getByRole("button", { name: /update pricing/i }),
       ).toBeEnabled(),
     );
+  });
+
+  it("requires terms acceptance before enabling monetization", async () => {
+    enableMonetizationMock.mockResolvedValue(
+      monetizedService({ isMonetized: true }),
+    );
+
+    render(<MonetizationSettings applicationId="app-123" />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /enable monetization/i }),
+    );
+
+    await screen.findByText(/accept the monetization terms/i);
+    expect(enableMonetizationMock).not.toHaveBeenCalled();
+
+    acceptTerms();
+    fireEvent.click(
+      screen.getByRole("button", { name: /enable monetization/i }),
+    );
+
+    await screen.findByText(/pricing persisted/i);
+    expect(enableMonetizationMock).toHaveBeenCalledWith(
+      "app-123",
+      "PER_CALL",
+      5,
+    );
+  });
+
+  it("opens the creator earnings dashboard with backend earnings", async () => {
+    getTotalEarningsMock.mockResolvedValue({ totalAllTimeEarnings: 42.5 });
+
+    render(
+      <MonetizationSettings
+        applicationId="app-123"
+        service={monetizedService()}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /view earnings dashboard/i }),
+    );
+
+    await screen.findByText(/creator earnings/i);
+    expect(await screen.findByText("$42.50")).toBeInTheDocument();
+    expect(getTotalEarningsMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/views/MonetizationSettings.tsx
+++ b/src/views/MonetizationSettings.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from "react";
 import {
+  CreatorEarnings,
   ManagedMcpService,
   PricingModel,
   enableMonetization,
+  getTotalEarnings,
   updatePricing,
 } from "@thorapi/services/monetization/ServiceMonetizationService";
 import { dispatchPricingUpdated } from "@thorapi/services/monetization/pricingEvents";
@@ -22,6 +24,10 @@ function validatePrice(costPerCall: number): string | null {
   }
 
   return null;
+}
+
+function currentMonth(): string {
+  return new Date().toISOString().slice(0, 7);
 }
 
 /**
@@ -44,6 +50,10 @@ export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
   );
   const [costPerCall, setCostPerCall] = useState(service?.costPerCall ?? 5.0);
   const [loading, setLoading] = useState(false);
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
+  const [earningsOpen, setEarningsOpen] = useState(false);
+  const [earningsLoading, setEarningsLoading] = useState(false);
+  const [earnings, setEarnings] = useState<CreatorEarnings | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
@@ -53,6 +63,18 @@ export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
     setPricingModel(service?.pricingModel ?? "PER_CALL");
     setCostPerCall(service?.costPerCall ?? 5.0);
   }, [service, serviceId, applicationId]);
+
+  const requireAcceptedTerms = (): boolean => {
+    if (acceptedTerms) {
+      return true;
+    }
+
+    setError(
+      "Accept the Monetization Terms before enabling or updating paid MCP pricing.",
+    );
+    setSuccess(false);
+    return false;
+  };
 
   const handleSaveError = (err: unknown, fallback: string) => {
     const message = err instanceof Error ? err.message : fallback;
@@ -75,6 +97,10 @@ export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
   };
 
   const handleEnableMonetization = async () => {
+    if (!requireAcceptedTerms()) {
+      return;
+    }
+
     const validationError = validatePrice(costPerCall);
     if (validationError) {
       setError(validationError);
@@ -101,6 +127,10 @@ export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
   };
 
   const handleUpdatePricing = async () => {
+    if (!requireAcceptedTerms()) {
+      return;
+    }
+
     const validationError = validatePrice(costPerCall);
     if (validationError) {
       setError(validationError);
@@ -134,6 +164,30 @@ export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
       );
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleViewEarnings = async () => {
+    setEarningsOpen(true);
+    setEarningsLoading(true);
+    setError(null);
+
+    try {
+      const result = await getTotalEarnings();
+      setEarnings({
+        month: currentMonth(),
+        totalEarned: result.totalAllTimeEarnings,
+        totalInvocations: 0,
+        payoutStatus: "PENDING",
+        totalAllTimeEarnings: result.totalAllTimeEarnings,
+      });
+    } catch (err) {
+      handleSaveError(
+        err,
+        "Earnings dashboard is unavailable. Check your session and try again.",
+      );
+    } finally {
+      setEarningsLoading(false);
     }
   };
 
@@ -257,16 +311,61 @@ export const MonetizationSettings: React.FC<MonetizationSettingsProps> = ({
               >
                 {loading ? "Updating..." : "Update Pricing"}
               </button>
-              <button className="btn btn-tertiary">
-                View Earnings Dashboard
+              <button
+                className="btn btn-tertiary"
+                onClick={() => void handleViewEarnings()}
+                disabled={earningsLoading}
+              >
+                {earningsLoading ? "Loading..." : "View Earnings Dashboard"}
               </button>
             </>
           )}
         </div>
 
+        {earningsOpen && (
+          <div className="earnings-dashboard" aria-live="polite">
+            <div>
+              <h4>Creator earnings</h4>
+              <p className="breakdown-note">
+                Earnings include settled creator revenue reported by ValkyrAI.
+              </p>
+            </div>
+            {earningsLoading ? (
+              <p className="breakdown-note">Loading creator earnings...</p>
+            ) : earnings ? (
+              <div className="earnings-grid">
+                <div className="earnings-metric">
+                  <span>All-time earnings</span>
+                  <strong>
+                    ${earnings.totalAllTimeEarnings?.toFixed(2) ?? "0.00"}
+                  </strong>
+                </div>
+                <div className="earnings-metric">
+                  <span>Payout status</span>
+                  <strong>{earnings.payoutStatus}</strong>
+                </div>
+                <div className="earnings-metric">
+                  <span>Reporting month</span>
+                  <strong>{earnings.month}</strong>
+                </div>
+              </div>
+            ) : (
+              <p className="breakdown-note">
+                Earnings will appear after paid MCP invocations settle.
+              </p>
+            )}
+          </div>
+        )}
+
         {/* Terms & Conditions */}
         <div className="terms-notice">
-          <input type="checkbox" id="agreeTerms" disabled={loading} />
+          <input
+            type="checkbox"
+            id="agreeTerms"
+            checked={acceptedTerms}
+            onChange={(event) => setAcceptedTerms(event.target.checked)}
+            disabled={loading}
+          />
           <label htmlFor="agreeTerms">
             I agree to the Monetization Terms & Service
           </label>


### PR DESCRIPTION
## Summary
- require monetization terms acceptance before enabling paid MCP pricing or saving pricing updates
- wire the earnings dashboard button to backend creator earnings instead of a dead button
- add focused React tests for terms enforcement and earnings rendering

## Verification
- npx jest --runInBand src/views/MonetizationSettings.test.tsx src/views/MonetizedServicesMarketplace.test.tsx src/views/MonetizedServicesMarketplace.helpers.test.ts
- npx eslint src/views/MonetizationSettings.tsx src/views/MonetizationSettings.test.tsx

## Notes
- npm test pretest is currently blocked by existing repo-wide tsconfig/test issues: missing Jest globals in unrelated tests and generated webview-ui thorapi models outside tsconfig.test rootDir.

Fixes ValkyrLabs/ValkyrAI#2890