### PR TITLE
[P0][#2908] Guide MCP server marketplace submission

### DIFF
--- a/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpSubmitCard.test.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpSubmitCard.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import McpSubmitCard, {
+  dispatchMcpSubmitAction,
+  mcpSubmitActions,
+} from "./McpSubmitCard";
+import { vscode } from "@thorapi/utils/vscode";
+
+vi.mock("@vscode/webview-ui-toolkit/react", () => ({
+  VSCodeButton: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@thorapi/utils/vscode", () => ({
+  vscode: { postMessage: vi.fn() },
+}));
+
+describe("McpSubmitCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the guided creator funnel entry instead of a static external link", () => {
+    render(<McpSubmitCard />);
+
+    expect(
+      screen.getByRole("heading", { name: "Publish MCP server" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Manifest and tool schema ready"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Pricing, support, and docs captured"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Detect local servers/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Create listing draft/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("https://valkyrlabs.com/mcp/marketplace"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("dispatches local server discovery with creator funnel telemetry", () => {
+    render(<McpSubmitCard />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Detect local servers/ }),
+    );
+
+    expect(vscode.postMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        type: "displayVSCodeInfo",
+        telemetryEvent: "mcp_submit_started",
+      }),
+    );
+    expect(vscode.postMessage).toHaveBeenNthCalledWith(2, {
+      type: "fetchLatestMcpServersFromHub",
+    });
+  });
+
+  it("routes draft creation to the marketplace submit path with ValorIDE source", () => {
+    dispatchMcpSubmitAction(mcpSubmitActions[2]);
+
+    expect(vscode.postMessage).toHaveBeenLastCalledWith({
+      type: "openInBrowser",
+      url: "https://valkyrlabs.com/mcp/marketplace/submit?source=valoride",
+    });
+  });
+});

--- a/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpSubmitCard.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpSubmitCard.tsx
@@ -1,4 +1,57 @@
-import { VscAdd } from "react-icons/vsc";
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import {
+  VscAdd,
+  VscChecklist,
+  VscRocket,
+  VscSettingsGear,
+} from "react-icons/vsc";
+import { vscode } from "@thorapi/utils/vscode";
+
+export type SubmitAction = {
+  label: string;
+  telemetryEvent: string;
+  message:
+    | { type: "fetchLatestMcpServersFromHub" }
+    | { type: "openMcpSettings" }
+    | { type: "openInBrowser"; url: string };
+};
+
+export const mcpSubmitActions: SubmitAction[] = [
+  {
+    label: "Detect local servers",
+    telemetryEvent: "mcp_submit_started",
+    message: { type: "fetchLatestMcpServersFromHub" },
+  },
+  {
+    label: "Review MCP settings",
+    telemetryEvent: "mcp_manifest_validated",
+    message: { type: "openMcpSettings" },
+  },
+  {
+    label: "Create listing draft",
+    telemetryEvent: "mcp_submit_completed",
+    message: {
+      type: "openInBrowser",
+      url: "https://valkyrlabs.com/mcp/marketplace/submit?source=valoride",
+    },
+  },
+];
+
+const readinessChecks = [
+  "Manifest and tool schema ready",
+  "Pricing, support, and docs captured",
+  "Review status returns to this marketplace",
+];
+
+export const dispatchMcpSubmitAction = (action: SubmitAction) => {
+  vscode.postMessage({
+    type: "displayVSCodeInfo",
+    text: `${action.telemetryEvent}:mcp-marketplace-submit`,
+    telemetryEvent: action.telemetryEvent,
+    telemetryProperties: { surface: "mcp_marketplace_submit_card" },
+  });
+  vscode.postMessage(action.message);
+};
 
 const McpSubmitCard = () => {
   return (
@@ -6,51 +59,99 @@ const McpSubmitCard = () => {
       style={{
         display: "flex",
         flexDirection: "column",
-        alignItems: "center",
-        gap: "12px",
+        gap: "14px",
         padding: "15px",
         margin: "20px",
         backgroundColor: "var(--vscode-textBlockQuote-background)",
         borderRadius: "6px",
+        border: "1px solid var(--vscode-panel-border)",
       }}
     >
-      {/* Icon */}
-      <VscAdd style={{ fontSize: "18px" }} />
-
-      {/* Content */}
       <div
         style={{
           display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          gap: "4px",
-          textAlign: "center",
-          maxWidth: "480px",
+          alignItems: "flex-start",
+          gap: "10px",
         }}
       >
-        <h3
+        <VscAdd
+          aria-hidden="true"
           style={{
-            margin: 0,
-            fontSize: "14px",
-            fontWeight: 600,
             color: "var(--vscode-foreground)",
+            flexShrink: 0,
+            fontSize: "18px",
+            marginTop: "1px",
           }}
-        >
-          Submit MCP Server
-        </h3>
-        <p
+        />
+        <div
           style={{
-            fontSize: "13px",
-            margin: 0,
-            color: "var(--vscode-descriptionForeground)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "4px",
+            minWidth: 0,
           }}
         >
-          Monetize your work and help others discover your great MCP servers!
-          Submit an MCP server to{" "}
-          <a href="https://valkyrlabs.com/mcp/marketplace">
-            https://valkyrlabs.com/mcp/marketplace
-          </a>
-        </p>
+          <h3
+            style={{
+              margin: 0,
+              fontSize: "14px",
+              fontWeight: 600,
+              color: "var(--vscode-foreground)",
+            }}
+          >
+            Publish MCP server
+          </h3>
+          <p
+            style={{
+              fontSize: "13px",
+              margin: 0,
+              color: "var(--vscode-descriptionForeground)",
+              lineHeight: 1.4,
+            }}
+          >
+            Package, validate, price, and submit an MCP server from ValorIDE
+            without losing marketplace context.
+          </p>
+        </div>
+      </div>
+
+      <div
+        aria-label="MCP submission readiness checks"
+        style={{
+          display: "grid",
+          gap: "6px",
+          fontSize: "12px",
+          color: "var(--vscode-descriptionForeground)",
+        }}
+      >
+        {readinessChecks.map((check) => (
+          <div
+            key={check}
+            style={{ display: "flex", alignItems: "center", gap: "6px" }}
+          >
+            <VscChecklist aria-hidden="true" />
+            <span>{check}</span>
+          </div>
+        ))}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "8px",
+        }}
+      >
+        {mcpSubmitActions.map((action, index) => (
+          <VSCodeButton
+            key={action.label}
+            appearance={index === 0 ? "primary" : "secondary"}
+            onClick={() => dispatchMcpSubmitAction(action)}
+          >
+            {index === 1 ? <VscSettingsGear /> : <VscRocket />}
+            {action.label}
+          </VSCodeButton>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace the static MCP submission link with a guided ValorIDE creator funnel entry
- add readiness checks for manifest/schema, pricing/docs, and marketplace review return
- wire creator actions through existing webview messages with telemetry metadata

## Verification
- yarn test McpSubmitCard.test.tsx
- npx --yes prettier@3.3.3 --check webview-ui/src/components/mcp/configuration/tabs/marketplace/McpSubmitCard.tsx webview-ui/src/components/mcp/configuration/tabs/marketplace/McpSubmitCard.test.tsx

## Notes
- Addresses ValkyrAI issue https://github.com/ValkyrLabs/ValkyrAI/issues/2908
- Full webview TypeScript check is currently blocked by pre-existing syntax errors in src/components/agentic/CapabilityCommandCenter.tsx and CapabilityCommandCenter.test.tsx on main.