### PR TITLE
feat(agentic): add GrayMatter quota recharge actions

### DIFF
--- a/webview-ui/src/components/account/AccountView.tsx
+++ b/webview-ui/src/components/account/AccountView.tsx
@@ -338,6 +338,10 @@ const AccountView = ({
         id: "graymatter",
         label: "GrayMatter memory",
         status: graymatterStatus,
+        balanceCredits: effectiveBalance,
+        estimatedUnlockCredits: graymatterStatus === "ready" ? undefined : 5,
+        blockedAction:
+          graymatterStatus === "quotaBlocked" ? "memory.write" : undefined,
         detail:
           graymatterStatus === "ready"
             ? "Memory, entitlement, and credit prerequisites look usable from the current webview state."
@@ -412,12 +416,19 @@ const AccountView = ({
           vscode.postMessage({ type: "showAccountViewClicked" });
           openRecoveryUrl();
           break;
-        case "buyCredits":
+        case "rechargeCredits":
           setActiveTab("account");
           openRecoveryUrl();
           break;
-        case "teamPlan":
+        case "upgradePlan":
           openRecoveryUrl();
+          break;
+        case "viewUsage":
+          setActiveTab("account");
+          if (authed) {
+            refetchUsage();
+            refetchPayments();
+          }
           break;
         case "openMcpMarketplace":
           vscode.postMessage({ type: "showMcpView", tab: "marketplace" });
@@ -430,11 +441,18 @@ const AccountView = ({
           });
           break;
         case "retry":
+        case "retryAfterRecharge":
           vscode.postMessage({ type: "fetchLatestMcpServersFromHub" });
           await refetchBalance();
           if (authed) {
             refetchUsage();
             refetchPayments();
+          }
+          if (action === "retryAfterRecharge") {
+            vscode.postMessage({
+              type: "displayVSCodeInfo",
+              text: `${capability.label} refreshed. Retry ${capability.blockedAction || "the blocked action"} when credits are restored.`,
+            });
           }
           break;
       }

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
@@ -21,7 +21,14 @@ import CapabilityCommandCenter, {
 const degradedSnapshots: CapabilitySnapshot[] = [
   { id: "graymatter", label: "GrayMatter", status: "unauthenticated" },
   { id: "graymatter", label: "GrayMatter RBAC", status: "rbacDenied" },
-  { id: "graymatter", label: "GrayMatter quota", status: "quotaBlocked" },
+  {
+    id: "graymatter",
+    label: "GrayMatter quota",
+    status: "quotaBlocked",
+    balanceCredits: 0,
+    estimatedUnlockCredits: 5,
+    blockedAction: "memory.write",
+  },
   { id: "graymatter", label: "GrayMatter unavailable", status: "unavailable" },
   { id: "mcp", label: "MCP", status: "disconnected" },
   { id: "swarm", label: "SWARM", status: "offline" },
@@ -45,12 +52,19 @@ describe("CapabilityCommandCenter", () => {
       cards
         .find((card) => card.status === "rbacDenied")
         ?.actions.map((action) => action.action),
-    ).toContain("teamPlan");
+    ).toContain("upgradePlan");
     expect(
       cards
         .find((card) => card.status === "quotaBlocked")
         ?.actions.map((action) => action.action),
-    ).toContain("buyCredits");
+    ).toEqual(
+      expect.arrayContaining([
+        "rechargeCredits",
+        "upgradePlan",
+        "viewUsage",
+        "retryAfterRecharge",
+      ]),
+    );
     expect(
       cards
         .find((card) => card.status === "unavailable")
@@ -66,6 +80,26 @@ describe("CapabilityCommandCenter", () => {
         .find((card) => card.status === "offline")
         ?.actions.map((action) => action.action),
     ).toContain("openDiagnostics");
+  });
+
+  it("renders quota balance, unlock cost, and recharge CTAs", () => {
+    render(
+      <CapabilityCommandCenter
+        snapshots={[degradedSnapshots[2]]}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText(/memory\.write is paused/i)).toBeInTheDocument();
+    expect(screen.getByText(/Balance: 0 credits/i)).toBeInTheDocument();
+    expect(screen.getByText(/Estimated unlock: 5 credits/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Recharge credits/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Upgrade plan/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /View usage/i })).toBeInTheDocument();
   });
 
   it("renders latest command failure detail without secret-looking payloads", () => {
@@ -130,7 +164,7 @@ describe("CapabilityCommandCenter", () => {
 
   it("builds safe recovery URLs with deep-link return context", () => {
     const url = new URL(
-      buildCapabilityRecoveryUrl("buyCredits", {
+      buildCapabilityRecoveryUrl("rechargeCredits", {
         id: "graymatter",
         status: "quotaBlocked",
       }) ?? "",
@@ -160,5 +194,36 @@ describe("CapabilityCommandCenter", () => {
         status: "offline",
       }),
     ).toBeUndefined();
+    expect(
+      buildCapabilityRecoveryUrl("viewUsage", {
+        id: "graymatter",
+        status: "quotaBlocked",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("emits the blocked action context when retry-after-recharge is clicked", async () => {
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+
+    render(
+      <CapabilityCommandCenter
+        snapshots={[degradedSnapshots[2]]}
+        onAction={onAction}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Retry after recharge/i }),
+    );
+
+    expect(onAction).toHaveBeenCalledWith(
+      "retryAfterRecharge",
+      expect.objectContaining({
+        id: "graymatter",
+        blockedAction: "memory.write",
+        status: "quotaBlocked",
+      }),
+    );
   });
 });

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
@@ -15,11 +15,13 @@ export type CapabilityStatus =
 export type CapabilityAction =
   | "signIn"
   | "setupGrayMatter"
-  | "buyCredits"
-  | "teamPlan"
+  | "rechargeCredits"
+  | "upgradePlan"
+  | "viewUsage"
   | "openMcpMarketplace"
   | "openDiagnostics"
-  | "retry";
+  | "retry"
+  | "retryAfterRecharge";
 
 export type LatestCommandFailure = {
   command: string;
@@ -33,6 +35,9 @@ export type CapabilitySnapshot = {
   status: CapabilityStatus;
   detail?: string;
   latestFailure?: LatestCommandFailure;
+  balanceCredits?: number;
+  estimatedUnlockCredits?: number;
+  blockedAction?: string;
 };
 
 export type CapabilityActionModel = {
@@ -46,6 +51,7 @@ export type CapabilityCardModel = CapabilitySnapshot & {
   tone: "ready" | "warning" | "danger";
   statusLabel: string;
   actions: CapabilityActionModel[];
+  recoverySummary?: string;
 };
 
 type CapabilityCommandCenterProps = {
@@ -92,8 +98,8 @@ const ACTIONS_BY_STATUS: Record<CapabilityStatus, CapabilityActionModel[]> = {
   ],
   rbacDenied: [
     {
-      action: "teamPlan",
-      label: "Request team access",
+      action: "upgradePlan",
+      label: "Team access",
       detail: "Open the team-plan path for RBAC and entitlement recovery.",
       variant: "primary",
     },
@@ -106,29 +112,41 @@ const ACTIONS_BY_STATUS: Record<CapabilityStatus, CapabilityActionModel[]> = {
   ],
   quotaBlocked: [
     {
-      action: "buyCredits",
-      label: "Buy credits",
+      action: "rechargeCredits",
+      label: "Recharge credits",
       detail: "Preserve the blocked action and route to credit recovery.",
       variant: "primary",
     },
     {
-      action: "retry",
-      label: "Retry after purchase",
-      detail: "Refresh balance, usage, payments, and MCP discovery.",
+      action: "upgradePlan",
+      label: "Upgrade plan",
+      detail: "Open plan upgrade options for sustained memory usage.",
+      variant: "secondary",
+    },
+    {
+      action: "viewUsage",
+      label: "View usage",
+      detail: "Review balance, usage, and recent payments before checkout.",
+      variant: "secondary",
+    },
+    {
+      action: "retryAfterRecharge",
+      label: "Retry after recharge",
+      detail: "Refresh credits and retry the blocked capability context.",
       variant: "secondary",
     },
   ],
   lowCredit: [
     {
-      action: "buyCredits",
+      action: "rechargeCredits",
       label: "Add credits",
       detail: "Top up before longer agentic runs exhaust the balance.",
       variant: "primary",
     },
     {
-      action: "retry",
-      label: "Refresh balance",
-      detail: "Reconcile the latest account balance and usage.",
+      action: "viewUsage",
+      label: "View usage",
+      detail: "Review balance, usage, and recent payments.",
       variant: "secondary",
     },
   ],
@@ -182,31 +200,62 @@ const toneColor: Record<CapabilityCardModel["tone"], string> = {
   danger: "var(--vscode-errorForeground)",
 };
 
+const FALLBACK_DETAIL: Record<CapabilityId, string> = {
+  graymatter:
+    "Durable memory needs auth, entitlement, credits, and API reachability.",
+  mcp: "MCP needs at least one connected server before tools can recover workflows.",
+  swarm: "SWARM needs local and ValkyrAI connectivity for multi-agent handoff.",
+};
+
+const formatCredits = (credits?: number): string =>
+  typeof credits === "number" && Number.isFinite(credits)
+    ? credits.toLocaleString(undefined, { maximumFractionDigits: 2 })
+    : "unknown";
+
+const buildQuotaSummary = (snapshot: CapabilitySnapshot): string | undefined => {
+  if (snapshot.status !== "quotaBlocked" && snapshot.status !== "lowCredit") {
+    return undefined;
+  }
+
+  const action = snapshot.blockedAction || "GrayMatter memory";
+  const balance = formatCredits(snapshot.balanceCredits);
+  const cost = formatCredits(snapshot.estimatedUnlockCredits);
+
+  if (snapshot.status === "quotaBlocked") {
+    return `${action} is paused. Balance: ${balance} credits. Estimated unlock: ${cost} credits.`;
+  }
+
+  return `${action} is close to quota. Balance: ${balance} credits. Estimated next use: ${cost} credits.`;
+};
+
 export const deriveCapabilityCards = (
   snapshots: CapabilitySnapshot[],
 ): CapabilityCardModel[] =>
   snapshots.map((snapshot) => {
     const status = STATUS_COPY[snapshot.status];
+    const recoverySummary = buildQuotaSummary(snapshot);
     return {
       ...snapshot,
       tone: status.tone,
       statusLabel: status.label,
+      detail: snapshot.detail || recoverySummary || FALLBACK_DETAIL[snapshot.id],
       actions: ACTIONS_BY_STATUS[snapshot.status],
+      recoverySummary,
     };
   });
 
 const EXTERNAL_RECOVERY_ROUTES: Partial<Record<CapabilityAction, string>> = {
   signIn: "https://valkyrlabs.com/signup",
   setupGrayMatter: "https://valkyrlabs.com/graymatter/install",
-  buyCredits: "https://valkyrlabs.com/buy-credits",
-  teamPlan: "https://valkyrlabs.com/pricing",
+  rechargeCredits: "https://valkyrlabs.com/buy-credits",
+  upgradePlan: "https://valkyrlabs.com/pricing",
 };
 
 const INTENT_BY_ACTION: Partial<Record<CapabilityAction, string>> = {
   signIn: "valoride-signin",
   setupGrayMatter: "graymatter-activation",
-  buyCredits: "credit-recovery",
-  teamPlan: "team-plan",
+  rechargeCredits: "credit-recovery",
+  upgradePlan: "team-plan",
 };
 
 export const buildCapabilityRecoveryUrl = (


### PR DESCRIPTION
## Summary
- repairs the Capability Command Center implementation so it uses the current snapshot/onAction API cleanly
- turns GrayMatter quota and low-credit states into explicit recharge, upgrade, usage, and retry-after-recharge actions
- carries balance, estimated unlock cost, and blocked action context from AccountView into the quota card

## Verification
- PASS: `cd webview-ui && npm test -- CapabilityCommandCenter.test.tsx`
- BLOCKED BASELINE: `cd webview-ui && npm run build` fails in this clean worktree because repo-level dependencies are missing/unresolved, including `react-bootstrap`, `formik`, `@reduxjs/toolkit`, and `@bufbuild/protobuf/wire`.

## Tracking
- Cross-links ValkyrAI Ready ticket ValkyrLabs/ValkyrAI#2957
