### PR TITLE
feat(graymatter): persist ValorIDE memory replay queue

### DIFF
--- a/src/core/storage/state-keys.ts
+++ b/src/core/storage/state-keys.ts
@@ -75,6 +75,7 @@ export type GlobalStateKey =
   | "authenticatedPrincipal"
   | "isLoggedIn"
   | "grayMatterSession"
+  | "grayMatterPendingWrites"
   | "agenticState"
   | "previousModeApiProvider"
   | "previousModeModelId"

--- a/src/services/graymatter/GrayMatterMemoryQueueStorage.test.ts
+++ b/src/services/graymatter/GrayMatterMemoryQueueStorage.test.ts
@@ -1,0 +1,75 @@
+import {
+  loadPendingGrayMatterWrites,
+  savePendingGrayMatterWrites,
+} from "./GrayMatterMemoryQueueStorage";
+import type { PendingGrayMatterWrite } from "./GrayMatterMemoryService";
+
+const createContext = (initial?: unknown) => {
+  let stored = initial;
+  return {
+    globalState: {
+      get: jest.fn(async () => stored),
+      update: jest.fn(async (_key: string, value: unknown) => {
+        stored = value;
+      }),
+    },
+  } as any;
+};
+
+describe("GrayMatterMemoryQueueStorage", () => {
+  it("loads valid queued writes from durable extension state", async () => {
+    const queued: PendingGrayMatterWrite = {
+      content: "Replay after restart.",
+      idempotencyKey: "todo:restart",
+      queuedAt: "2026-06-05T06:33:00.000Z",
+      tags: ["graymatter"],
+      type: "todo",
+    };
+
+    const context = createContext([queued, { malformed: true }]);
+
+    await expect(loadPendingGrayMatterWrites(context)).resolves.toEqual([
+      queued,
+    ]);
+    expect(context.globalState.get).toHaveBeenCalledWith(
+      "grayMatterPendingWrites",
+    );
+  });
+
+  it("clears durable queue state when replay drains all pending writes", async () => {
+    const context = createContext([
+      {
+        content: "old",
+        idempotencyKey: "todo:old",
+        queuedAt: "2026-06-05T06:33:00.000Z",
+        type: "todo",
+      },
+    ]);
+
+    await savePendingGrayMatterWrites(context, []);
+
+    expect(context.globalState.update).toHaveBeenCalledWith(
+      "grayMatterPendingWrites",
+      undefined,
+    );
+  });
+
+  it("persists a defensive copy of queued write arrays", async () => {
+    const context = createContext();
+    const queued: PendingGrayMatterWrite = {
+      content: "Needs replay.",
+      idempotencyKey: "context:1",
+      metadata: { source: "valoride" },
+      queuedAt: "2026-06-05T06:33:00.000Z",
+      tags: ["memory"],
+      type: "context",
+    };
+
+    await savePendingGrayMatterWrites(context, [queued]);
+
+    const [, saved] = context.globalState.update.mock.calls[0];
+    expect(saved).toEqual([queued]);
+    expect(saved[0]).not.toBe(queued);
+    expect(saved[0].tags).not.toBe(queued.tags);
+  });
+});

--- a/src/services/graymatter/GrayMatterMemoryQueueStorage.ts
+++ b/src/services/graymatter/GrayMatterMemoryQueueStorage.ts
@@ -1,0 +1,73 @@
+import type * as vscode from "vscode";
+import { getGlobalState, updateGlobalState } from "@core/storage/state";
+import type { GrayMatterClient } from "./GrayMatterClient";
+import { GrayMatterMemoryService } from "./GrayMatterMemoryService";
+import type { PendingGrayMatterWrite } from "./GrayMatterMemoryService";
+
+const PENDING_WRITES_KEY = "grayMatterPendingWrites";
+
+export const loadPendingGrayMatterWrites = async (
+  context: vscode.ExtensionContext,
+): Promise<PendingGrayMatterWrite[]> => {
+  const stored = await getGlobalState(context, PENDING_WRITES_KEY);
+  if (!Array.isArray(stored)) {
+    return [];
+  }
+
+  return stored
+    .map(toPendingWrite)
+    .filter((write): write is PendingGrayMatterWrite => Boolean(write));
+};
+
+export const savePendingGrayMatterWrites = async (
+  context: vscode.ExtensionContext,
+  writes: PendingGrayMatterWrite[],
+): Promise<void> => {
+  await updateGlobalState(
+    context,
+    PENDING_WRITES_KEY,
+    writes.length ? writes.map(toStoredWrite) : undefined,
+  );
+};
+
+export const createGrayMatterMemoryService = (
+  context: vscode.ExtensionContext,
+  client: Pick<GrayMatterClient, "writeMemory">,
+): GrayMatterMemoryService =>
+  new GrayMatterMemoryService({
+    loadPendingWrites: () => loadPendingGrayMatterWrites(context),
+    savePendingWrites: (writes) => savePendingGrayMatterWrites(context, writes),
+    writeMemory: (input) => client.writeMemory(input),
+  });
+
+const toPendingWrite = (value: unknown): PendingGrayMatterWrite | undefined => {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const candidate = value as Partial<PendingGrayMatterWrite>;
+  if (
+    typeof candidate.content !== "string" ||
+    typeof candidate.idempotencyKey !== "string" ||
+    typeof candidate.queuedAt !== "string" ||
+    typeof candidate.type !== "string"
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...candidate,
+    content: candidate.content,
+    idempotencyKey: candidate.idempotencyKey,
+    queuedAt: candidate.queuedAt,
+    type: candidate.type,
+  } as PendingGrayMatterWrite;
+};
+
+const toStoredWrite = (
+  write: PendingGrayMatterWrite,
+): PendingGrayMatterWrite => ({
+  ...write,
+  metadata: write.metadata ? { ...write.metadata } : undefined,
+  tags: write.tags ? [...write.tags] : undefined,
+});

--- a/src/views/graymatter/GrayMatterMemoryPanel.ts
+++ b/src/views/graymatter/GrayMatterMemoryPanel.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { getGlobalState } from "@core/storage/state";
 import type { GrayMatterSessionState } from "@services/graymatter/GrayMatterSessionService";
+import { loadPendingGrayMatterWrites } from "@services/graymatter/GrayMatterMemoryQueueStorage";
 
 export class GrayMatterMemoryPanel {
   static readonly viewType = "valoride.graymatter.memoryPanel";
@@ -26,6 +27,8 @@ const renderMemoryPanel = async (context: vscode.ExtensionContext) => {
   const status = session?.status ?? "unauthenticated";
   const checkedAt = session?.checkedAt ?? "never";
   const capabilities = session?.capabilities;
+  const pendingWrites = await loadPendingGrayMatterWrites(context);
+  const pendingPreview = pendingWrites.slice(0, 5);
 
   return `<!doctype html>
 <html lang="en">
@@ -43,6 +46,9 @@ const renderMemoryPanel = async (context: vscode.ExtensionContext) => {
     section { border: 1px solid var(--vscode-panel-border); border-radius: 6px; padding: 12px; }
     .status { color: var(--vscode-descriptionForeground); font-size: 12px; }
     .empty { color: var(--vscode-descriptionForeground); margin: 0; }
+    .queue { display: grid; gap: 8px; margin: 0; padding: 0; list-style: none; }
+    .queue li { border-top: 1px solid var(--vscode-panel-border); padding-top: 8px; }
+    .queue .meta { color: var(--vscode-descriptionForeground); font-size: 12px; }
     code { color: var(--vscode-textLink-foreground); }
   </style>
 </head>
@@ -66,11 +72,34 @@ const renderMemoryPanel = async (context: vscode.ExtensionContext) => {
     </section>
     <section>
       <h2>Session Log</h2>
-      <p class="empty">Reads and writes are tracked by the GrayMatter services during agent tasks.</p>
+      ${renderQueueSummary(pendingWrites.length, pendingPreview)}
     </section>
   </main>
 </body>
 </html>`;
+};
+
+const renderQueueSummary = (
+  pendingCount: number,
+  pendingPreview: Awaited<ReturnType<typeof loadPendingGrayMatterWrites>>,
+) => {
+  if (!pendingCount) {
+    return `<p class="empty">No pending memory writes. Reads and writes are tracked by the GrayMatter services during agent tasks.</p>`;
+  }
+
+  const hiddenCount = Math.max(0, pendingCount - pendingPreview.length);
+  const items = pendingPreview
+    .map(
+      (write) => `<li>
+        <div><code>${escapeHtml(write.type)}</code> ${escapeHtml(write.content.slice(0, 140))}</div>
+        <div class="meta">Queued ${escapeHtml(write.queuedAt)}${write.lastErrorKind ? ` · ${escapeHtml(write.lastErrorKind)}` : ""}${write.attempts ? ` · attempts ${write.attempts}` : ""}</div>
+      </li>`,
+    )
+    .join("");
+
+  return `<p class="empty">${pendingCount} memory write${pendingCount === 1 ? "" : "s"} queued for replay.</p>
+    <ul class="queue">${items}</ul>
+    ${hiddenCount ? `<p class="empty">${hiddenCount} more queued item${hiddenCount === 1 ? "" : "s"} hidden.</p>` : ""}`;
 };
 
 const escapeHtml = (value: string) =>


### PR DESCRIPTION
## Summary
- Add a durable VS Code global-state adapter for queued GrayMatter memory writes.
- Add a factory that wires `GrayMatterMemoryService` to durable queue load/save behavior.
- Surface pending replay items in the GrayMatter memory panel so queued memories survive restart visibly instead of disappearing into process memory.

Related ValkyrAI issue: https://github.com/ValkyrLabs/ValkyrAI/issues/2978

## Verification
- `npx jest --runTestsByPath src/services/graymatter/GrayMatterMemoryQueueStorage.test.ts src/services/graymatter/GrayMatterMemoryService.test.ts --runInBand`
- `npx tsc --noEmit --pretty false --skipLibCheck` hit Node 4 GB heap OOM before diagnostics.
- `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit --pretty false --skipLibCheck` was stopped after prolonged no-output runtime; targeted tests passed and CI should run the broader compile matrix.