### PR TITLE
feat(agentic): preserve activation recovery handoff

### DIFF
--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { fireEvent, render, screen } from "@testing-library/react";
 import CapabilityCommandCenter from "./CapabilityCommandCenter";
 
 const mockUseExtensionState = vi.fn();
@@ -138,7 +137,6 @@ describe("CapabilityCommandCenter", () => {
   });
 
   it("turns GrayMatter quota blocks into recharge, upgrade, and usage recovery actions", async () => {
-    const user = userEvent.setup();
     mockUseExtensionState.mockReturnValue({
       apiConfiguration: {
         apiProvider: "openai-native",
@@ -190,26 +188,34 @@ describe("CapabilityCommandCenter", () => {
       "GrayMatter is waiting on credits for graymatter.memory. Balance: 0 credits. Estimated unlock: 25 credits.",
     );
 
-    await user.click(screen.getByRole("button", { name: "Recharge credits" }));
+    fireEvent.click(screen.getByRole("button", { name: "Recharge credits" }));
     expect(mockPostMessage).toHaveBeenLastCalledWith({
       type: "openInBrowser",
-      url: "https://api-0.valkyrlabs.com/buy-credits?source=valoride-graymatter-quota&intent=resume-blocked-action&capability=graymatter.memory&resumeCommand=cmd-quota-1&action=Recall+project+memory",
+      url: "https://api-0.valkyrlabs.com/buy-credits?source=valoride-graymatter-quota&intent=resume-blocked-action&returnTo=valoride%3A%2F%2Fagentic-command-center%2Frecovery%3Faction%3Dresume_blocked_action&capability=graymatter.memory&resumeCommand=cmd-quota-1&action=Recall+project+memory",
+    });
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      event: "valoride_activation_recovery_action",
+      payload: {
+        action: "recharge_credits",
+        status: "quota",
+        surface: "graymatter",
+      },
+      type: "trackFunnelEvent",
     });
 
-    await user.click(screen.getByRole("button", { name: "Upgrade plan" }));
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade plan" }));
     expect(mockPostMessage).toHaveBeenLastCalledWith({
       type: "openInBrowser",
-      url: "https://api-0.valkyrlabs.com/pricing?source=valoride-graymatter-quota&intent=resume-blocked-action&capability=graymatter.memory&resumeCommand=cmd-quota-1&action=Recall+project+memory",
+      url: "https://api-0.valkyrlabs.com/pricing?source=valoride-graymatter-quota&intent=resume-blocked-action&returnTo=valoride%3A%2F%2Fagentic-command-center%2Frecovery%3Faction%3Dresume_blocked_action&capability=graymatter.memory&resumeCommand=cmd-quota-1&action=Recall+project+memory",
     });
 
-    await user.click(screen.getByRole("button", { name: "View usage" }));
+    fireEvent.click(screen.getByRole("button", { name: "View usage" }));
     expect(mockPostMessage).toHaveBeenLastCalledWith({
       type: "showAccountViewClicked",
     });
   });
 
   it("shows sign-in and workspace recovery actions for unauthenticated sessions", async () => {
-    const user = userEvent.setup();
     mockUseExtensionState.mockReturnValue({
       apiConfiguration: {
         valkyraiHost: "https://api-0.valkyrlabs.com/v1",
@@ -222,22 +228,31 @@ describe("CapabilityCommandCenter", () => {
 
     render(<CapabilityCommandCenter />);
 
-    await user.click(
+    fireEvent.click(
       screen.getByRole("button", { name: "Sign in to ValkyrAI" }),
     );
     expect(mockPostMessage).toHaveBeenLastCalledWith({
-      type: "accountLoginClicked",
+      type: "openInBrowser",
+      url: "https://api-0.valkyrlabs.com/graymatter/activate?source=valoride-graymatter-auth&returnTo=valoride%3A%2F%2Fagentic-command-center%2Frecovery%3Faction%3Dsign_in",
+    });
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      event: "valoride_activation_recovery_action",
+      payload: {
+        action: "sign_in",
+        status: "unauthenticated",
+        surface: "graymatter",
+      },
+      type: "trackFunnelEvent",
     });
 
-    await user.click(screen.getByRole("button", { name: "Create workspace" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create workspace" }));
     expect(mockPostMessage).toHaveBeenLastCalledWith({
       type: "openInBrowser",
-      url: "https://api-0.valkyrlabs.com/signup?source=valoride-graymatter-workspace",
+      url: "https://api-0.valkyrlabs.com/signup?source=valoride-graymatter-workspace&returnTo=valoride%3A%2F%2Fagentic-command-center%2Frecovery%3Faction%3Dcreate_workspace",
     });
   });
 
   it("surfaces RBAC, unavailable, and MCP recovery actions", async () => {
-    const user = userEvent.setup();
     mockUseExtensionState.mockReturnValue({
       apiConfiguration: {
         valkyraiHost: "https://api-0.valkyrlabs.com/v1",
@@ -250,32 +265,40 @@ describe("CapabilityCommandCenter", () => {
 
     render(<CapabilityCommandCenter />);
 
-    await user.click(screen.getByRole("button", { name: "Request access" }));
+    fireEvent.click(screen.getByRole("button", { name: "Request access" }));
     expect(mockPostMessage).toHaveBeenLastCalledWith({
       type: "openInBrowser",
-      url: "https://api-0.valkyrlabs.com/account?source=valoride-graymatter-rbac-request",
+      url: "https://api-0.valkyrlabs.com/account?source=valoride-graymatter-rbac-request&returnTo=valoride%3A%2F%2Fagentic-command-center%2Frecovery%3Faction%3Drequest_access",
     });
 
-    await user.click(screen.getByRole("button", { name: "Open admin RBAC" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open admin RBAC" }));
     expect(mockPostMessage).toHaveBeenLastCalledWith({
       type: "openInBrowser",
-      url: "https://api-0.valkyrlabs.com/admin/rbac?source=valoride-graymatter-rbac-admin",
+      url: "https://api-0.valkyrlabs.com/admin/rbac?source=valoride-graymatter-rbac-admin&returnTo=valoride%3A%2F%2Fagentic-command-center%2Frecovery%3Faction%3Dopen_admin_rbac",
     });
 
-    await user.click(screen.getByRole("button", { name: "Retry discovery" }));
+    fireEvent.click(screen.getByRole("button", { name: "Retry discovery" }));
     expect(mockPostMessage).toHaveBeenLastCalledWith({
       type: "fetchLatestMcpServersFromHub",
     });
 
-    await user.click(screen.getByRole("button", { name: "Open MCP setup" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open MCP setup" }));
     expect(mockPostMessage).toHaveBeenLastCalledWith({
       type: "showMcpView",
       tab: "installed",
     });
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      event: "valoride_activation_recovery_action",
+      payload: {
+        action: "open_mcp_setup",
+        status: "unknown",
+        surface: "mcp",
+      },
+      type: "trackFunnelEvent",
+    });
   });
 
   it("offers SWARM recovery and failed command details without exposing user identity", async () => {
-    const user = userEvent.setup();
     mockUseExtensionState.mockReturnValue({
       apiConfiguration: {
         valkyraiHost: "https://api-0.valkyrlabs.com/v1",
@@ -324,12 +347,12 @@ describe("CapabilityCommandCenter", () => {
       screen.getByText("Remote command · swarm.dispatch · approval required"),
     ).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Retry SWARM" }));
+    fireEvent.click(screen.getByRole("button", { name: "Retry SWARM" }));
     expect(mockPostMessage).toHaveBeenLastCalledWith({
       type: "webviewDidLaunch",
     });
 
-    await user.click(screen.getByRole("button", { name: "Open setup" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open setup" }));
     expect(mockPostMessage).toHaveBeenLastCalledWith({
       type: "showMcpView",
       tab: "installed",

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
@@ -197,6 +197,7 @@ const quotaRecoveryUrl = (
   const context = quotaActionContext(grayMatterSession, latestCommand);
   url.searchParams.set("source", "valoride-graymatter-quota");
   url.searchParams.set("intent", "resume-blocked-action");
+  url.searchParams.set("returnTo", valorideReturnTo("resume_blocked_action"));
   if (context.capabilityId) {
     url.searchParams.set("capability", context.capabilityId);
   }
@@ -207,6 +208,37 @@ const quotaRecoveryUrl = (
     url.searchParams.set("action", context.label);
   }
   return url.toString();
+};
+
+const valorideReturnTo = (action: string): string =>
+  `valoride://agentic-command-center/recovery?action=${encodeURIComponent(action)}`;
+
+const hostedRecoveryUrl = (
+  path: string,
+  state: Record<string, any>,
+  source: string,
+  action: string,
+): string => {
+  const url = hostedUrl(path, state);
+  url.searchParams.set("source", source);
+  url.searchParams.set("returnTo", valorideReturnTo(action));
+  return url.toString();
+};
+
+const trackRecoveryAction = (
+  status: string | undefined,
+  action: string,
+  surface: "graymatter" | "mcp",
+) => {
+  vscode.postMessage({
+    event: "valoride_activation_recovery_action",
+    payload: {
+      action,
+      status: status ?? "unknown",
+      surface,
+    },
+    type: "trackFunnelEvent",
+  });
 };
 
 const formatCredits = (value?: number): string | undefined => {
@@ -252,7 +284,8 @@ const GrayMatterQuotaRecovery = ({
   const context = quotaActionContext(grayMatterSession, latestCommand);
   const blockedAction = context.capabilityId ?? "GrayMatter action";
 
-  const openRecoveryUrl = (path: string) => {
+  const openRecoveryUrl = (path: string, action: string) => {
+    trackRecoveryAction(grayMatterSession?.status, action, "graymatter");
     vscode.postMessage({
       type: "openInBrowser",
       url: quotaRecoveryUrl(path, state, grayMatterSession, latestCommand),
@@ -270,15 +303,28 @@ const GrayMatterQuotaRecovery = ({
         </span>
       </div>
       <div className="capability-command-center__quota-actions">
-        <button type="button" onClick={() => openRecoveryUrl("/buy-credits")}>
+        <button
+          type="button"
+          onClick={() => openRecoveryUrl("/buy-credits", "recharge_credits")}
+        >
           Recharge credits
         </button>
-        <button type="button" onClick={() => openRecoveryUrl("/pricing")}>
+        <button
+          type="button"
+          onClick={() => openRecoveryUrl("/pricing", "upgrade_plan")}
+        >
           Upgrade plan
         </button>
         <button
           type="button"
-          onClick={() => vscode.postMessage({ type: "showAccountViewClicked" })}
+          onClick={() => {
+            trackRecoveryAction(
+              grayMatterSession?.status,
+              "view_usage",
+              "graymatter",
+            );
+            vscode.postMessage({ type: "showAccountViewClicked" });
+          }}
         >
           View usage
         </button>
@@ -294,10 +340,12 @@ const GrayMatterRecoveryActions = ({
   grayMatterSession?: GrayMatterLike;
   state: Record<string, any>;
 }) => {
-  const openHosted = (path: string, source: string) => {
-    const url = hostedUrl(path, state);
-    url.searchParams.set("source", source);
-    vscode.postMessage({ type: "openInBrowser", url: url.toString() });
+  const openHosted = (path: string, source: string, action: string) => {
+    trackRecoveryAction(grayMatterSession?.status, action, "graymatter");
+    vscode.postMessage({
+      type: "openInBrowser",
+      url: hostedRecoveryUrl(path, state, source, action),
+    });
   };
 
   if (grayMatterSession?.status === "unauthenticated") {
@@ -313,7 +361,11 @@ const GrayMatterRecoveryActions = ({
           <button
             type="button"
             onClick={() =>
-              openHosted("/graymatter/activate", "valoride-graymatter-auth")
+              openHosted(
+                "/graymatter/activate",
+                "valoride-graymatter-auth",
+                "sign_in",
+              )
             }
           >
             Sign in to ValkyrAI
@@ -321,7 +373,11 @@ const GrayMatterRecoveryActions = ({
           <button
             type="button"
             onClick={() =>
-              openHosted("/signup", "valoride-graymatter-workspace")
+              openHosted(
+                "/signup",
+                "valoride-graymatter-workspace",
+                "create_workspace",
+              )
             }
           >
             Create workspace
@@ -344,7 +400,11 @@ const GrayMatterRecoveryActions = ({
           <button
             type="button"
             onClick={() =>
-              openHosted("/account", "valoride-graymatter-rbac-request")
+              openHosted(
+                "/account",
+                "valoride-graymatter-rbac-request",
+                "request_access",
+              )
             }
           >
             Request access
@@ -352,7 +412,11 @@ const GrayMatterRecoveryActions = ({
           <button
             type="button"
             onClick={() =>
-              openHosted("/admin/rbac", "valoride-graymatter-rbac-admin")
+              openHosted(
+                "/admin/rbac",
+                "valoride-graymatter-rbac-admin",
+                "open_admin_rbac",
+              )
             }
           >
             Open admin RBAC
@@ -378,6 +442,7 @@ const GrayMatterRecoveryActions = ({
               openHosted(
                 "/graymatter/activate",
                 "valoride-graymatter-diagnostics",
+                "open_diagnostics",
               )
             }
           >
@@ -385,7 +450,14 @@ const GrayMatterRecoveryActions = ({
           </button>
           <button
             type="button"
-            onClick={() => vscode.postMessage({ type: "webviewDidLaunch" })}
+            onClick={() => {
+              trackRecoveryAction(
+                grayMatterSession?.status,
+                "retry_setup",
+                "graymatter",
+              );
+              vscode.postMessage({ type: "webviewDidLaunch" });
+            }}
           >
             Retry setup
           </button>
@@ -531,17 +603,19 @@ const CapabilityCommandCenter = () => {
           <div className="capability-command-center__quota-actions">
             <button
               type="button"
-              onClick={() =>
-                vscode.postMessage({ type: "fetchLatestMcpServersFromHub" })
-              }
+              onClick={() => {
+                trackRecoveryAction(undefined, "retry_discovery", "mcp");
+                vscode.postMessage({ type: "fetchLatestMcpServersFromHub" });
+              }}
             >
               Retry discovery
             </button>
             <button
               type="button"
-              onClick={() =>
-                vscode.postMessage({ type: "showMcpView", tab: "installed" })
-              }
+              onClick={() => {
+                trackRecoveryAction(undefined, "open_mcp_setup", "mcp");
+                vscode.postMessage({ type: "showMcpView", tab: "installed" });
+              }}
             >
               Open MCP setup
             </button>


### PR DESCRIPTION
## Summary
- Adds return-to deep-link context to ValorIDE activation recovery URLs for quota, auth, workspace, and RBAC repair actions.
- Emits non-secret funnel events for GrayMatter and MCP blocked-state recovery clicks.
- Keeps command-center tests on existing testing-library dependencies and covers the new telemetry/return context.

Related: ValkyrLabs/ValkyrAI#2859

## Verification
- npm --prefix webview-ui run test -- CapabilityCommandCenter.test.tsx
- git diff --check

## Notes
- npm --prefix webview-ui run lint -- src/components/agentic/CapabilityCommandCenter.tsx src/components/agentic/CapabilityCommandCenter.test.tsx is blocked by the existing webview ESLint config loading as ESM while using __dirname.