### PR TITLE
fix(startup): keep ValorIDE reveal opt-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -370,6 +370,21 @@
           "default": false,
           "markdownDescription": "When enabled, ValorIDE prints the full precision_search_and_replace result report after each edit."
         },
+        "valoride.startup.revealSidebar": {
+          "type": "string",
+          "enum": [
+            "manual",
+            "firstInstall",
+            "always"
+          ],
+          "enumDescriptions": [
+            "Do not reveal or focus ValorIDE on VS Code startup.",
+            "Reveal ValorIDE once, then keep future startups unobtrusive.",
+            "Reveal ValorIDE every time VS Code startup finishes."
+          ],
+          "default": "manual",
+          "markdownDescription": "Controls whether ValorIDE automatically reveals its activity bar view when VS Code starts. The default keeps existing editor focus until the user opens ValorIDE explicitly."
+        },
         "valoride.valkyrai.host": {
           "type": "string",
           "default": "https://api-0.valkyrlabs.com",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,11 @@ import {
 } from "./services/llmPromptService";
 import { getAllExtensionState, getSecret } from "./core/storage/state";
 import { SelectedLlmDetails } from "@shared/llm";
+import {
+  getStartupRevealMode,
+  shouldRevealSidebarOnStartup,
+  STARTUP_REVEAL_GLOBAL_KEY,
+} from "./startupRevealPolicy";
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -290,14 +295,7 @@ export function activate(context: vscode.ExtensionContext) {
     IS_DEV && IS_DEV === "true",
   );
 
-  // Ensure our Activity Bar container is visible, then focus our view
-  // This helps recover if the container was hidden from prior layout changes
-  void vscode.commands.executeCommand(
-    "workbench.view.extension.valoride-activitybar",
-  );
-  // Proactively reveal the sidebar view once after activation
-  // This helps surface the Activity Bar icon if the container was hidden/cached
-  void vscode.commands.executeCommand(`${WebviewProvider.sideBarId}.focus`);
+  void maybeRevealValorideOnStartup(context);
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
@@ -931,6 +929,31 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   return createValorIDEAPI(outputChannel, sidebarWebview.controller);
+}
+
+async function maybeRevealValorideOnStartup(context: vscode.ExtensionContext) {
+  try {
+    const revealMode = getStartupRevealMode(
+      vscode.workspace.getConfiguration("valoride"),
+    );
+
+    if (!shouldRevealSidebarOnStartup(revealMode, context)) {
+      Logger.log(`Startup reveal skipped; mode=${revealMode}`);
+      return;
+    }
+
+    Logger.log(`Startup reveal requested; mode=${revealMode}`);
+    await vscode.commands.executeCommand(
+      "workbench.view.extension.valoride-activitybar",
+    );
+    await vscode.commands.executeCommand(`${WebviewProvider.sideBarId}.focus`);
+
+    if (revealMode === "firstInstall") {
+      await context.globalState.update(STARTUP_REVEAL_GLOBAL_KEY, true);
+    }
+  } catch (error) {
+    Logger.log(`Startup reveal failed: ${error}`);
+  }
 }
 
 // TODO: Find a solution for automatically removing DEV related content from production builds.

--- a/src/startupRevealPolicy.test.ts
+++ b/src/startupRevealPolicy.test.ts
@@ -1,0 +1,46 @@
+import {
+  getStartupRevealMode,
+  shouldRevealSidebarOnStartup,
+  STARTUP_REVEAL_SETTING,
+} from "./startupRevealPolicy";
+
+describe("startup reveal policy", () => {
+  const configuration = (value: unknown) => ({
+    get: jest.fn(<T>(section: string, defaultValue: T): T => {
+      expect(section).toBe(STARTUP_REVEAL_SETTING);
+      return (value ?? defaultValue) as T;
+    }),
+  });
+
+  const context = (completed: boolean) => ({
+    globalState: {
+      get: jest.fn(
+        (_key: string, defaultValue: boolean) => completed ?? defaultValue,
+      ),
+    },
+  });
+
+  it("defaults to manual startup so returning workspaces keep editor focus", () => {
+    const mode = getStartupRevealMode(configuration(undefined));
+
+    expect(mode).toBe("manual");
+    expect(shouldRevealSidebarOnStartup(mode, context(false))).toBe(false);
+  });
+
+  it("reveals once for first-install mode until the global marker is set", () => {
+    expect(shouldRevealSidebarOnStartup("firstInstall", context(false))).toBe(
+      true,
+    );
+    expect(shouldRevealSidebarOnStartup("firstInstall", context(true))).toBe(
+      false,
+    );
+  });
+
+  it("allows explicit always mode for users who want startup reveal", () => {
+    expect(shouldRevealSidebarOnStartup("always", context(true))).toBe(true);
+  });
+
+  it("treats unknown configuration values as manual", () => {
+    expect(getStartupRevealMode(configuration("surprise"))).toBe("manual");
+  });
+});

--- a/src/startupRevealPolicy.ts
+++ b/src/startupRevealPolicy.ts
@@ -1,0 +1,50 @@
+export type StartupRevealMode = "manual" | "firstInstall" | "always";
+
+export const STARTUP_REVEAL_SETTING = "startup.revealSidebar";
+export const STARTUP_REVEAL_GLOBAL_KEY = "valoride.startupReveal.completed";
+
+type WorkspaceConfigurationLike = {
+  get<T>(section: string, defaultValue: T): T;
+};
+
+type GlobalStateLike = {
+  get<T>(key: string, defaultValue: T): T;
+};
+
+export type StartupRevealContext = {
+  globalState: GlobalStateLike;
+};
+
+export function getStartupRevealMode(
+  configuration: WorkspaceConfigurationLike,
+): StartupRevealMode {
+  const configured = configuration.get<StartupRevealMode>(
+    STARTUP_REVEAL_SETTING,
+    "manual",
+  );
+
+  if (
+    configured === "manual" ||
+    configured === "firstInstall" ||
+    configured === "always"
+  ) {
+    return configured;
+  }
+
+  return "manual";
+}
+
+export function shouldRevealSidebarOnStartup(
+  mode: StartupRevealMode,
+  context: StartupRevealContext,
+): boolean {
+  if (mode === "always") {
+    return true;
+  }
+
+  if (mode === "firstInstall") {
+    return !context.globalState.get<boolean>(STARTUP_REVEAL_GLOBAL_KEY, false);
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- stops ValorIDE from forcing the activity bar/sidebar into focus on normal VS Code startup
- adds an explicit startup reveal policy with manual, first-install, and always modes
- covers the policy with focused regression tests

Refs ValkyrLabs/ValkyrAI#2863

## Verification
- npx -y -p typescript@5.4.5 tsc --noEmit --strict src/startupRevealPolicy.ts
- npx -y tsx -e "startup reveal policy smoke"
- npx -y prettier@3.3.3 --check package.json src/extension.ts src/startupRevealPolicy.ts src/startupRevealPolicy.test.ts

## Notes
- Full yarn install/check-types could not run in this fresh worktree because the checked-in yarn.lock is already out of sync with package.json; no dependency files were changed.