### PR TITLE
[P0][#2863] Stop ValorIDE sidebar auto-focus on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,11 @@
         "category": "ValorIDE"
       },
       {
+        "command": "valoride.revealSidebar",
+        "title": "Open Sidebar",
+        "category": "ValorIDE"
+      },
+      {
         "command": "valoride.diagnostics",
         "title": "Show Diagnostics",
         "category": "ValorIDE"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ import { initializeSwarmPromptBroadcaster } from "./services/swarmPromptBroadcas
 import { initializeThorAPIModelRegistry } from "./services/thorapiModelRegistry";
 import { initializeRatingService } from "./services/ratingService";
 import { initializeStatusBarService } from "./services/StatusBarService";
+import { revealValorideSidebar } from "./services/startupReveal";
 import {
   initializeLLMPromptService,
   SelectedPrompt,
@@ -290,14 +291,9 @@ export function activate(context: vscode.ExtensionContext) {
     IS_DEV && IS_DEV === "true",
   );
 
-  // Ensure our Activity Bar container is visible, then focus our view
-  // This helps recover if the container was hidden from prior layout changes
-  void vscode.commands.executeCommand(
-    "workbench.view.extension.valoride-activitybar",
+  Logger.log(
+    "Startup reveal skipped; use ValorIDE: Open Sidebar or Reset Layout to focus the view.",
   );
-  // Proactively reveal the sidebar view once after activation
-  // This helps surface the Activity Bar icon if the container was hidden/cached
-  void vscode.commands.executeCommand(`${WebviewProvider.sideBarId}.focus`);
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
@@ -438,6 +434,13 @@ export function activate(context: vscode.ExtensionContext) {
       "valoride.openInNewTab",
       openValorIDEInNewTab,
     ),
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand("valoride.revealSidebar", async () => {
+      await revealValorideSidebar(WebviewProvider.sideBarId, (command) =>
+        vscode.commands.executeCommand(command),
+      );
+    }),
   );
 
   context.subscriptions.push(
@@ -918,11 +921,10 @@ export function activate(context: vscode.ExtensionContext) {
         Logger.log(`Error running resetViewLocations: ${err}`);
       }
 
-      // Bring our container and view to the front after reset
-      void vscode.commands.executeCommand(
-        "workbench.view.extension.valoride-activitybar",
+      // Bring our container and view to the front after an explicit reset.
+      await revealValorideSidebar(WebviewProvider.sideBarId, (command) =>
+        vscode.commands.executeCommand(command),
       );
-      void vscode.commands.executeCommand(`${WebviewProvider.sideBarId}.focus`);
 
       vscode.window.showInformationMessage(
         "View locations reset. ValorIDE sidebar restored (if previously moved).",

--- a/src/services/startupReveal.test.ts
+++ b/src/services/startupReveal.test.ts
@@ -1,0 +1,23 @@
+import * as assert from "node:assert/strict";
+import { describe, it } from "mocha";
+import {
+  revealValorideSidebar,
+  VALORIDE_ACTIVITYBAR_COMMAND,
+  valorideSidebarFocusCommand,
+} from "./startupReveal";
+
+describe("startup reveal policy", () => {
+  it("keeps ValorIDE reveal behind an explicit command helper", async () => {
+    const commands: string[] = [];
+
+    await revealValorideSidebar("valoride-dev.SidebarProvider", (command) => {
+      commands.push(command);
+      return Promise.resolve(undefined);
+    });
+
+    assert.deepEqual(commands, [
+      VALORIDE_ACTIVITYBAR_COMMAND,
+      valorideSidebarFocusCommand("valoride-dev.SidebarProvider"),
+    ]);
+  });
+});

--- a/src/services/startupReveal.ts
+++ b/src/services/startupReveal.ts
@@ -1,0 +1,13 @@
+export const VALORIDE_ACTIVITYBAR_COMMAND =
+  "workbench.view.extension.valoride-activitybar";
+
+export const valorideSidebarFocusCommand = (sideBarId: string) =>
+  `${sideBarId}.focus`;
+
+export async function revealValorideSidebar(
+  sideBarId: string,
+  executeCommand: (command: string) => PromiseLike<unknown> | Promise<unknown>,
+) {
+  await executeCommand(VALORIDE_ACTIVITYBAR_COMMAND);
+  await executeCommand(valorideSidebarFocusCommand(sideBarId));
+}


### PR DESCRIPTION
## Summary
- Stops ValorIDE activation from automatically focusing the activity bar/sidebar during normal startup.
- Adds an explicit `ValorIDE: Open Sidebar` command for intentional reveal.
- Reuses a small reveal helper from both the new command and the existing Reset Layout recovery command.
- Adds focused regression coverage for the reveal helper command ordering.

References ValkyrLabs/ValkyrAI#2863.

## Verification
- PASS: `./node_modules/.bin/tsc --noEmit --module commonjs --moduleResolution node --target es2022 --types node,mocha src/services/startupReveal.ts src/services/startupReveal.test.ts`
- PASS: `./node_modules/.bin/eslint src/services/startupReveal.ts src/services/startupReveal.test.ts src/extension.ts`
- BASELINE BLOCKED: `yarn run compile-tests` fails before this patch on mixed Jest/Mocha globals plus ThorAPI generated files outside `rootDir`.
- BASELINE BLOCKED: `yarn run check-types` fails before this patch on missing webview deps (`@testing-library/user-event`, `three`) and existing BuyCredits test signature errors.
