### PR TITLE
fix(valoride): refresh ThorAPI prompts after auth restore

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,7 +39,6 @@ import {
   ThorApiLlmDetailsClient,
 } from "./services/llmPromptService";
 import { getAllExtensionState, getSecret } from "./core/storage/state";
-import { SelectedLlmDetails } from "@shared/llm";
 
 /*
 Built using https://github.com/microsoft/vscode-webview-ui-toolkit
@@ -51,6 +50,43 @@ https://github.com/microsoft/vscode-webview-ui-toolkit-samples/tree/main/framewo
 */
 
 let outputChannel: vscode.OutputChannel;
+
+async function initializeWorkspaceLlmPromptService(
+  context: vscode.ExtensionContext,
+  workspaceRoot: string,
+  authTokenOverride?: string,
+): Promise<void> {
+  const { apiConfiguration, selectedLlmDetails } =
+    await getAllExtensionState(context);
+  const manualSelection: SelectedPrompt | undefined = selectedLlmDetails
+    ? {
+        llmDetailsId: selectedLlmDetails.id,
+        name: selectedLlmDetails.name,
+        prompt: selectedLlmDetails.prompt,
+        mode: selectedLlmDetails.mode,
+        tags: selectedLlmDetails.tags,
+        source:
+          selectedLlmDetails.source === "fallback" ? "fallback" : "thorapi",
+        stackSpecific: true,
+      }
+    : undefined;
+  const authToken =
+    authTokenOverride ??
+    (await getSecret(context, "jwtToken")) ??
+    apiConfiguration.valkyraiJwt ??
+    apiConfiguration.valorideApiKey;
+  const llmDetailsClient =
+    authToken && !manualSelection
+      ? new ThorApiLlmDetailsClient(authToken, apiConfiguration.valkyraiHost)
+      : undefined;
+
+  await initializeLLMPromptService(
+    workspaceRoot,
+    outputChannel,
+    llmDetailsClient,
+    manualSelection,
+  );
+}
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -89,38 +125,7 @@ export function activate(context: vscode.ExtensionContext) {
   // Initialize LLMPromptService (load base prompt + manual overrides)
   void (async () => {
     try {
-      const { apiConfiguration, selectedLlmDetails } =
-        await getAllExtensionState(context);
-      const manualSelection: SelectedPrompt | undefined = selectedLlmDetails
-        ? {
-            llmDetailsId: selectedLlmDetails.id,
-            name: selectedLlmDetails.name,
-            prompt: selectedLlmDetails.prompt,
-            mode: selectedLlmDetails.mode,
-            tags: selectedLlmDetails.tags,
-            source:
-              selectedLlmDetails.source === "fallback" ? "fallback" : "thorapi",
-            stackSpecific: true,
-          }
-        : undefined;
-      const authToken =
-        (await getSecret(context, "jwtToken")) ??
-        apiConfiguration.valkyraiJwt ??
-        apiConfiguration.valorideApiKey;
-      const llmDetailsClient =
-        authToken && !manualSelection
-          ? new ThorApiLlmDetailsClient(
-              authToken,
-              apiConfiguration.valkyraiHost,
-            )
-          : undefined;
-
-      await initializeLLMPromptService(
-        workspaceRoot,
-        outputChannel,
-        llmDetailsClient,
-        manualSelection,
-      );
+      await initializeWorkspaceLlmPromptService(context, workspaceRoot);
       Logger.log("LLMPromptService initialized successfully");
     } catch (error) {
       Logger.log(`LLMPromptService initialization failed: ${error}`);
@@ -190,6 +195,12 @@ export function activate(context: vscode.ExtensionContext) {
 
       if (authResult.success) {
         Logger.log("Successfully restored authentication from stored tokens");
+        await initializeWorkspaceLlmPromptService(
+          context,
+          workspaceRoot,
+          authResult.tokens?.jwtToken,
+        );
+        Logger.log("LLMPromptService refreshed with restored authentication");
         // Notify the webview that authentication was restored
         sidebarWebview.controller.postMessageToWebview({
           type: "loginSuccess",

--- a/src/services/__tests__/llmPromptService.test.ts
+++ b/src/services/__tests__/llmPromptService.test.ts
@@ -186,4 +186,26 @@ describe("LLMPromptService", () => {
     ).rejects.toThrow("requires signed-in auth");
     expect(get).not.toHaveBeenCalled();
   });
+
+  it("classifies RBAC-denied ThorAPI LLMDetails responses", async () => {
+    const get = vi.fn().mockRejectedValue({ response: { status: 403 } });
+    vi.mocked(axios.create).mockReturnValue({ get } as any);
+
+    const client = new ThorApiLlmDetailsClient("token", "https://api.test");
+
+    await expect(
+      client.query({ tags: ["typescript", "thorapi"], limit: 1 }),
+    ).rejects.toThrow("denied by RBAC policy");
+  });
+
+  it("classifies unreachable ThorAPI LLMDetails responses as offline", async () => {
+    const get = vi.fn().mockRejectedValue({ request: {} });
+    vi.mocked(axios.create).mockReturnValue({ get } as any);
+
+    const client = new ThorApiLlmDetailsClient("token", "https://api.test");
+
+    await expect(
+      client.query({ tags: ["typescript", "thorapi"], limit: 1 }),
+    ).rejects.toThrow("offline or unreachable");
+  });
 });

--- a/src/services/__tests__/llmPromptService.test.ts
+++ b/src/services/__tests__/llmPromptService.test.ts
@@ -172,4 +172,16 @@ describe("LLMPromptService", () => {
       tags: ["typescript", "thorapi", "production"],
     });
   });
+
+  it("classifies missing auth before querying ThorAPI LLMDetails", async () => {
+    const get = vi.fn();
+    vi.mocked(axios.create).mockReturnValue({ get } as any);
+
+    const client = new ThorApiLlmDetailsClient(undefined, "https://api.test");
+
+    await expect(
+      client.query({ tags: ["typescript", "thorapi"], limit: 1 }),
+    ).rejects.toThrow("requires signed-in auth");
+    expect(get).not.toHaveBeenCalled();
+  });
 });

--- a/src/services/__tests__/llmPromptService.test.ts
+++ b/src/services/__tests__/llmPromptService.test.ts
@@ -133,26 +133,28 @@ describe("LLMPromptService", () => {
   it("normalizes wrapped ThorAPI LLMDetails responses and ranks tag matches", async () => {
     const get = vi.fn().mockResolvedValue({
       data: {
-        content: [
-          {
-            id: "generic",
-            name: "Generic Prompt",
-            initialPrompt: "Generic fallback.",
-            tags: "production",
-            ratingScore: 5,
-          },
-          {
-            id: "thorapi",
-            name: "ThorAPI Prompt",
-            initialPrompt: "Use ThorAPI contracts first.",
-            tags: JSON.stringify(["typescript", "thorapi"]),
-            metaData: JSON.stringify({
-              promptType: "APPEND",
-              promptTags: ["production", "thorapi"],
-            }),
-            ratingScore: 4.5,
-          },
-        ],
+        data: {
+          content: [
+            {
+              id: "generic",
+              name: "Generic Prompt",
+              initialPrompt: "Generic fallback.",
+              tags: "production",
+              ratingScore: 5,
+            },
+            {
+              id: "thorapi",
+              name: "ThorAPI Prompt",
+              initialPrompt: "Use ThorAPI contracts first.",
+              tags: JSON.stringify(["typescript", "thorapi"]),
+              metaData: JSON.stringify({
+                promptType: "append",
+                promptTags: ["production", "thorapi"],
+              }),
+              ratingScore: 4.5,
+            },
+          ],
+        },
       },
     });
     vi.mocked(axios.create).mockReturnValue({ get } as any);

--- a/src/services/llmPromptService.ts
+++ b/src/services/llmPromptService.ts
@@ -449,7 +449,9 @@ const parsePromptTags = (value: unknown): string[] => {
 };
 
 const normalizePromptMode = (value: unknown): LlmPromptMode => {
-  return value === "APPEND" ? "APPEND" : "SYSTEM";
+  return typeof value === "string" && value.toUpperCase() === "APPEND"
+    ? "APPEND"
+    : "SYSTEM";
 };
 
 const toPromptSummary = (record: any): LlmDetailsSummary | null => {
@@ -496,6 +498,10 @@ const extractLlmDetailsRows = (payload: any): any[] => {
     if (Array.isArray(payload?.[key])) {
       return payload[key];
     }
+  }
+
+  if (payload?.data && typeof payload.data === "object") {
+    return extractLlmDetailsRows(payload.data);
   }
 
   return [];

--- a/src/services/llmPromptService.ts
+++ b/src/services/llmPromptService.ts
@@ -518,6 +518,27 @@ const scorePrompt = (prompt: LlmDetailsSummary, tags: string[]): number => {
   return tagScore * 100 + (prompt.ratingScore ?? 0);
 };
 
+const classifyThorApiQueryError = (error: any): Error => {
+  const status = error?.response?.status;
+  if (status === 401) {
+    return new Error(
+      "ThorAPI LLMDetails query requires refreshed sign-in auth",
+    );
+  }
+  if (status === 403) {
+    return new Error("ThorAPI LLMDetails query was denied by RBAC policy");
+  }
+  if (status === 429) {
+    return new Error("ThorAPI LLMDetails query was rate limited");
+  }
+  if (error?.request && !error?.response) {
+    return new Error("ThorAPI LLMDetails query is offline or unreachable");
+  }
+  return error instanceof Error
+    ? error
+    : new Error("ThorAPI LLMDetails query failed");
+};
+
 export class ThorApiLlmDetailsClient implements LlmDetailsClient {
   private readonly http: AxiosInstance;
   private readonly hasAuth: boolean;
@@ -541,7 +562,12 @@ export class ThorApiLlmDetailsClient implements LlmDetailsClient {
         trashed: false,
       }),
     );
-    const response = await this.http.get(`/LlmDetails?example=${example}`);
+    let response;
+    try {
+      response = await this.http.get(`/LlmDetails?example=${example}`);
+    } catch (error) {
+      throw classifyThorApiQueryError(error);
+    }
     const rows = extractLlmDetailsRows(response.data);
 
     return rows


### PR DESCRIPTION
## Summary
- refactors ValorIDE LLM prompt startup into a reusable initializer
- re-runs prompt initialization after stored authentication is restored so ThorAPI LLMDetails can load without requiring a window reload
- preserves manual prompt selection precedence over remote LLMDetails
- classifies ThorAPI prompt query failures for refreshed auth, RBAC denial, rate limits, and offline fallback states

## Verification
- yarn lint --quiet src/extension.ts
- npx prettier --check src/extension.ts
- yarn check-types (fails on existing baseline: missing @testing-library/user-event and three, plus existing BuyCredits test argument errors)
- npx vitest run src/services/__tests__/llmPromptService.test.ts
- npx prettier --check src/services/llmPromptService.ts src/services/__tests__/llmPromptService.test.ts
- npx eslint src/services/llmPromptService.ts src/services/__tests__/llmPromptService.test.ts

Related: ValkyrLabs/ValkyrAI#2985