### PR TITLE
feat(agentic): add SWARM recovery actions

### DIFF
--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.css
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.css
@@ -88,6 +88,15 @@
   flex: 0 0 auto;
 }
 
+.capability-command-center__command-detail {
+  color: var(--vscode-descriptionForeground);
+  flex: 1 1 100%;
+  font-size: 0.92em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .capability-command-center__quota {
   align-items: center;
   background: rgba(210, 153, 34, 0.12);

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
@@ -91,7 +91,9 @@ describe("CapabilityCommandCenter", () => {
 
     expect(screen.queryByText("jm")).not.toBeInTheDocument();
     expect(screen.queryByText("api-0.valkyrlabs.com")).not.toBeInTheDocument();
-    expect(screen.queryByText("openai-native / gpt-5.5")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("openai-native / gpt-5.5"),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("GrayMatter Ready")).toBeInTheDocument();
     expect(
       screen.getByText("memory query, memory write, swarm ops, swarm graph"),
@@ -130,7 +132,9 @@ describe("CapabilityCommandCenter", () => {
     expect(screen.getByText("GrayMatter Sign in needed")).toBeInTheDocument();
     expect(screen.getByText("SWARM Offline")).toBeInTheDocument();
     expect(screen.getByText("MCP 0/0")).toBeInTheDocument();
-    expect(screen.queryByText("No recent remote commands")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("No recent remote commands"),
+    ).not.toBeInTheDocument();
   });
 
   it("turns GrayMatter quota blocks into recharge, upgrade, and usage recovery actions", async () => {
@@ -218,7 +222,9 @@ describe("CapabilityCommandCenter", () => {
 
     render(<CapabilityCommandCenter />);
 
-    await user.click(screen.getByRole("button", { name: "Sign in to ValkyrAI" }));
+    await user.click(
+      screen.getByRole("button", { name: "Sign in to ValkyrAI" }),
+    );
     expect(mockPostMessage).toHaveBeenLastCalledWith({
       type: "openInBrowser",
       url: "https://api-0.valkyrlabs.com/graymatter/activate?source=valoride-graymatter-auth",
@@ -263,6 +269,68 @@ describe("CapabilityCommandCenter", () => {
     });
 
     await user.click(screen.getByRole("button", { name: "Open MCP setup" }));
+    expect(mockPostMessage).toHaveBeenLastCalledWith({
+      type: "showMcpView",
+      tab: "installed",
+    });
+  });
+
+  it("offers SWARM recovery and failed command details without exposing user identity", async () => {
+    const user = userEvent.setup();
+    mockUseExtensionState.mockReturnValue({
+      apiConfiguration: {
+        valkyraiHost: "https://api-0.valkyrlabs.com/v1",
+      },
+      authenticatedUser: {
+        username: "jm",
+        email: "john@example.com",
+      },
+      grayMatterSession: {
+        status: "ready",
+        capabilities: {
+          swarmOps: true,
+        },
+      },
+      mcpServers: [],
+      agenticState: {
+        approvalPolicy: "ask",
+        swarm: {
+          status: "error",
+          lastError: "Registration rejected by policy",
+        },
+        recentCommands: [
+          {
+            commandId: "cmd-swarm-1",
+            capabilityId: "swarm.dispatch",
+            source: "swarm",
+            status: "failed",
+            startedAt: "2026-05-13T17:00:30.000Z",
+            approved: false,
+            requiresApproval: true,
+            toolLabel: "Remote command",
+          },
+        ],
+      },
+    });
+
+    render(<CapabilityCommandCenter />);
+
+    expect(screen.queryByText("jm")).not.toBeInTheDocument();
+    expect(screen.queryByText("john@example.com")).not.toBeInTheDocument();
+    expect(screen.getByText("SWARM Error")).toBeInTheDocument();
+    expect(screen.getAllByText("Registration rejected by policy")).toHaveLength(
+      2,
+    );
+    expect(
+      screen.getByText("Remote command · swarm.dispatch · approval required"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Retry SWARM" }));
+    expect(mockPostMessage).toHaveBeenLastCalledWith({
+      type: "webviewDidLaunch",
+    });
+
+    await user.click(screen.getByRole("button", { name: "Open setup" }));
     expect(mockPostMessage).toHaveBeenLastCalledWith({
       type: "showMcpView",
       tab: "installed",

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
@@ -141,6 +141,23 @@ const commandStatus = (
     : titleCaseStatus(command.status);
 };
 
+const commandFailureDetail = (
+  command:
+    | AgenticCapabilityCommandCenterState["recentCommands"][number]
+    | undefined,
+): string | undefined => {
+  if (!command || command.status !== "failed") {
+    return undefined;
+  }
+  return [
+    command.toolLabel,
+    command.capabilityId,
+    command.requiresApproval ? "approval required" : undefined,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+};
+
 const hostedUrl = (path: string, state: Record<string, any>): URL => {
   const configuredHost = state.apiConfiguration?.valkyraiHost;
   let origin = "https://valkyrlabs.com";
@@ -288,18 +305,24 @@ const GrayMatterRecoveryActions = ({
       <div className="capability-command-center__quota" role="alert">
         <div className="capability-command-center__quota-copy">
           <FaCreditCard aria-hidden="true" />
-          <span>Sign in to restore GrayMatter memory and activation flows.</span>
+          <span>
+            Sign in to restore GrayMatter memory and activation flows.
+          </span>
         </div>
         <div className="capability-command-center__quota-actions">
           <button
             type="button"
-            onClick={() => openHosted("/graymatter/activate", "valoride-graymatter-auth")}
+            onClick={() =>
+              openHosted("/graymatter/activate", "valoride-graymatter-auth")
+            }
           >
             Sign in to ValkyrAI
           </button>
           <button
             type="button"
-            onClick={() => openHosted("/signup", "valoride-graymatter-workspace")}
+            onClick={() =>
+              openHosted("/signup", "valoride-graymatter-workspace")
+            }
           >
             Create workspace
           </button>
@@ -313,18 +336,24 @@ const GrayMatterRecoveryActions = ({
       <div className="capability-command-center__quota" role="alert">
         <div className="capability-command-center__quota-copy">
           <FaCreditCard aria-hidden="true" />
-          <span>Missing role/scope detected. Request access or open RBAC controls.</span>
+          <span>
+            Missing role/scope detected. Request access or open RBAC controls.
+          </span>
         </div>
         <div className="capability-command-center__quota-actions">
           <button
             type="button"
-            onClick={() => openHosted("/account", "valoride-graymatter-rbac-request")}
+            onClick={() =>
+              openHosted("/account", "valoride-graymatter-rbac-request")
+            }
           >
             Request access
           </button>
           <button
             type="button"
-            onClick={() => openHosted("/admin/rbac", "valoride-graymatter-rbac-admin")}
+            onClick={() =>
+              openHosted("/admin/rbac", "valoride-graymatter-rbac-admin")
+            }
           >
             Open admin RBAC
           </button>
@@ -338,12 +367,19 @@ const GrayMatterRecoveryActions = ({
       <div className="capability-command-center__quota" role="alert">
         <div className="capability-command-center__quota-copy">
           <FaCreditCard aria-hidden="true" />
-          <span>GrayMatter is unavailable. Open diagnostics and retry setup.</span>
+          <span>
+            GrayMatter is unavailable. Open diagnostics and retry setup.
+          </span>
         </div>
         <div className="capability-command-center__quota-actions">
           <button
             type="button"
-            onClick={() => openHosted("/graymatter/activate", "valoride-graymatter-diagnostics")}
+            onClick={() =>
+              openHosted(
+                "/graymatter/activate",
+                "valoride-graymatter-diagnostics",
+              )
+            }
           >
             Open diagnostics
           </button>
@@ -359,6 +395,49 @@ const GrayMatterRecoveryActions = ({
   }
 
   return null;
+};
+
+const SwarmRecoveryActions = ({
+  agenticState,
+  latestCommand,
+}: {
+  agenticState?: AgenticCapabilityCommandCenterState;
+  latestCommand?: AgenticCapabilityCommandCenterState["recentCommands"][number];
+}) => {
+  const swarmStatus = agenticState?.swarm?.status ?? "offline";
+  if (swarmStatus === "online" || swarmStatus === "busy") {
+    return null;
+  }
+
+  const detail =
+    agenticState?.swarm?.lastError ??
+    commandFailureDetail(latestCommand) ??
+    "SWARM is offline. Reconnect before routing remote commands.";
+
+  return (
+    <div className="capability-command-center__quota" role="status">
+      <div className="capability-command-center__quota-copy">
+        <FaNetworkWired aria-hidden="true" />
+        <span>{detail}</span>
+      </div>
+      <div className="capability-command-center__quota-actions">
+        <button
+          type="button"
+          onClick={() => vscode.postMessage({ type: "webviewDidLaunch" })}
+        >
+          Retry SWARM
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            vscode.postMessage({ type: "showMcpView", tab: "installed" })
+          }
+        >
+          Open setup
+        </button>
+      </div>
+    </div>
+  );
 };
 
 const CapabilityCommandCenter = () => {
@@ -415,6 +494,11 @@ const CapabilityCommandCenter = () => {
             <span className="capability-command-center__command-status">
               {commandStatus(latestCommand)}
             </span>
+            {commandFailureDetail(latestCommand) ? (
+              <span className="capability-command-center__command-detail">
+                {commandFailureDetail(latestCommand)}
+              </span>
+            ) : null}
           </div>
         ) : null}
       </div>
@@ -427,24 +511,37 @@ const CapabilityCommandCenter = () => {
         />
       ) : null}
       {grayMatterSession?.status !== "quota" ? (
-        <GrayMatterRecoveryActions grayMatterSession={grayMatterSession} state={state} />
+        <GrayMatterRecoveryActions
+          grayMatterSession={grayMatterSession}
+          state={state}
+        />
       ) : null}
+      <SwarmRecoveryActions
+        agenticState={agenticState}
+        latestCommand={latestCommand}
+      />
       {mcp.tone === "warn" ? (
         <div className="capability-command-center__quota" role="status">
           <div className="capability-command-center__quota-copy">
             <FaPlug aria-hidden="true" />
-            <span>MCP connectivity needs attention. Retry discovery or open setup.</span>
+            <span>
+              MCP connectivity needs attention. Retry discovery or open setup.
+            </span>
           </div>
           <div className="capability-command-center__quota-actions">
             <button
               type="button"
-              onClick={() => vscode.postMessage({ type: "fetchLatestMcpServersFromHub" })}
+              onClick={() =>
+                vscode.postMessage({ type: "fetchLatestMcpServersFromHub" })
+              }
             >
               Retry discovery
             </button>
             <button
               type="button"
-              onClick={() => vscode.postMessage({ type: "showMcpView", tab: "installed" })}
+              onClick={() =>
+                vscode.postMessage({ type: "showMcpView", tab: "installed" })
+              }
             >
               Open MCP setup
             </button>


### PR DESCRIPTION
## Summary
- add SWARM offline/error recovery actions to the Capability Command Center
- surface failed command details without exposing authenticated user identity
- cover SWARM recovery buttons and failure context in the webview component test

## Tests
- npm --prefix webview-ui run test -- CapabilityCommandCenter.test.tsx
- npx --prefix webview-ui prettier --write webview-ui/src/components/agentic/CapabilityCommandCenter.tsx webview-ui/src/components/agentic/CapabilityCommandCenter.css webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx

## Notes
- Linked ValkyrAI issue: #3083
- Webview lint is currently blocked by the existing ESLint 9 ESM config error: eslint.config.js uses __dirname while webview-ui/package.json sets type=module.