### PR TITLE
[P0][#2859] Route ValorIDE capability recovery actions

### DIFF
--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@tailwindcss/vite": "^4.0.12",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",

--- a/webview-ui/src/components/account/AccountView.tsx
+++ b/webview-ui/src/components/account/AccountView.tsx
@@ -49,6 +49,7 @@ import CapabilityCommandCenter, {
   CapabilityAction,
   CapabilityCardModel,
   CapabilitySnapshot,
+  buildCapabilityRecoveryUrl,
 } from "../agentic/CapabilityCommandCenter";
 import {
   storeJwtToken,
@@ -389,6 +390,12 @@ const AccountView = ({
         messageId: Math.random().toString(36).slice(2, 12),
         timestamp: Date.now(),
       };
+      const recoveryUrl = buildCapabilityRecoveryUrl(action, capability);
+      const openRecoveryUrl = () => {
+        if (recoveryUrl) {
+          vscode.postMessage({ type: "openInBrowser", url: recoveryUrl });
+        }
+      };
 
       window.dispatchEvent(
         new CustomEvent("websocket-send", { detail: activationEvent }),
@@ -398,19 +405,19 @@ const AccountView = ({
         case "signIn":
           setActiveTab("login");
           vscode.postMessage({ type: "accountLoginClicked" });
+          openRecoveryUrl();
           break;
         case "setupGrayMatter":
           setActiveTab("account");
           vscode.postMessage({ type: "showAccountViewClicked" });
+          openRecoveryUrl();
           break;
         case "buyCredits":
           setActiveTab("account");
+          openRecoveryUrl();
           break;
         case "teamPlan":
-          vscode.postMessage({
-            type: "openInBrowser",
-            url: "https://valkyrlabs.com/pricing?utm_source=valoride&utm_campaign=capability-command-center&intent=team-plan",
-          });
+          openRecoveryUrl();
           break;
         case "openMcpMarketplace":
           vscode.postMessage({ type: "showMcpView", tab: "marketplace" });

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@vscode/webview-ui-toolkit/react", () => ({
 
 import CapabilityCommandCenter, {
   CapabilitySnapshot,
+  buildCapabilityRecoveryUrl,
   deriveCapabilityCards,
 } from "./CapabilityCommandCenter";
 
@@ -125,5 +126,39 @@ describe("CapabilityCommandCenter", () => {
     );
 
     expect(screen.getAllByRole("button", { name: "Refresh" })).toHaveLength(3);
+  });
+
+  it("builds safe recovery URLs with deep-link return context", () => {
+    const url = new URL(
+      buildCapabilityRecoveryUrl("buyCredits", {
+        id: "graymatter",
+        status: "quotaBlocked",
+      }) ?? "",
+    );
+
+    expect(url.origin).toBe("https://valkyrlabs.com");
+    expect(url.pathname).toBe("/buy-credits");
+    expect(url.searchParams.get("intent")).toBe("credit-recovery");
+    expect(url.searchParams.get("capability")).toBe("graymatter");
+    expect(url.searchParams.get("blockedState")).toBe("quotaBlocked");
+    expect(url.searchParams.get("returnTo")).toBe(
+      "valoride://capability-command-center",
+    );
+    expect(url.toString()).not.toMatch(/token|jwt|secret|api[_-]?key/i);
+  });
+
+  it("keeps local-only recovery actions off external URLs", () => {
+    expect(
+      buildCapabilityRecoveryUrl("retry", {
+        id: "mcp",
+        status: "disconnected",
+      }),
+    ).toBeUndefined();
+    expect(
+      buildCapabilityRecoveryUrl("openDiagnostics", {
+        id: "swarm",
+        status: "offline",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
@@ -195,6 +195,44 @@ export const deriveCapabilityCards = (
     };
   });
 
+const EXTERNAL_RECOVERY_ROUTES: Partial<Record<CapabilityAction, string>> = {
+  signIn: "https://valkyrlabs.com/signup",
+  setupGrayMatter: "https://valkyrlabs.com/graymatter/install",
+  buyCredits: "https://valkyrlabs.com/buy-credits",
+  teamPlan: "https://valkyrlabs.com/pricing",
+};
+
+const INTENT_BY_ACTION: Partial<Record<CapabilityAction, string>> = {
+  signIn: "valoride-signin",
+  setupGrayMatter: "graymatter-activation",
+  buyCredits: "credit-recovery",
+  teamPlan: "team-plan",
+};
+
+export const buildCapabilityRecoveryUrl = (
+  action: CapabilityAction,
+  capability: Pick<CapabilityCardModel, "id" | "status">,
+) => {
+  const baseUrl = EXTERNAL_RECOVERY_ROUTES[action];
+  if (!baseUrl) {
+    return undefined;
+  }
+
+  const url = new URL(baseUrl);
+  url.search = new URLSearchParams({
+    source: "valoride",
+    utm_source: "valoride",
+    utm_campaign: "capability-command-center",
+    intent: INTENT_BY_ACTION[action] ?? action,
+    product: "ValorIDE",
+    capability: capability.id,
+    blockedState: capability.status,
+    returnTo: "valoride://capability-command-center",
+  }).toString();
+
+  return url.toString();
+};
+
 const safeFailureMessage = (message: string) =>
   message.replace(/(token|jwt|secret|api[_-]?key)\s*[:=]\s*\S+/gi, "$1=[redacted]");
 

--- a/webview-ui/yarn.lock
+++ b/webview-ui/yarn.lock
@@ -760,7 +760,7 @@
     "@tailwindcss/oxide" "4.1.16"
     tailwindcss "4.1.16"
 
-"@testing-library/dom@^10.0.0", "@testing-library/dom@>=7.21.4":
+"@testing-library/dom@^10.0.0", "@testing-library/dom@^10.4.1", "@testing-library/dom@>=7.21.4":
   version "10.4.1"
   resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz"
   integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==


### PR DESCRIPTION
Links ValkyrLabs/ValkyrAI#2859

## Summary
- add safe external recovery URLs for ValorIDE capability actions with source, intent, capability, blocked state, and return context
- route sign-in, GrayMatter setup, credits, and team-plan recovery CTAs through those URLs after explicit user clicks
- cover recovery URL construction and local-only action behavior in the command center tests

## Verification
- npm test -- CapabilityCommandCenter.test.tsx
- git diff --check
- npm run build:test (baseline blocked: existing missing dependencies/proto modules and generated TS errors outside this patch)