### PR TITLE
fix: make ValorIDE startup reveal opt-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -456,6 +456,21 @@
           "default": false,
           "description": "Disables extension from spawning browser session."
         },
+        "valoride.startupReveal": {
+          "type": "string",
+          "enum": [
+            "never",
+            "firstInstall",
+            "always"
+          ],
+          "enumDescriptions": [
+            "Never focus ValorIDE automatically during VS Code startup.",
+            "Focus ValorIDE once per installation, then leave returning sessions alone.",
+            "Focus ValorIDE on every VS Code startup."
+          ],
+          "default": "never",
+          "description": "Controls whether ValorIDE reveals and focuses its sidebar during extension startup."
+        },
         "valoride.modelSettings.o3Mini.reasoningEffort": {
           "type": "string",
           "enum": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import { ErrorService } from "./services/error/ErrorService";
 import { initializeTestMode, cleanupTestMode } from "./services/test/TestMode";
 import { registerUrlCommands } from "./commands/urlCommands";
 import { registerAliasCommands } from "./commands/aliasCommands";
+import { maybeRevealValorIDESidebarOnStartup } from "./startupActivation";
 import { StartupAuthService } from "./services/auth/StartupAuthService";
 import { ValorideAuthCodeExchangeService } from "./services/auth/ValorideAuthCodeExchangeService";
 import {
@@ -59,16 +60,14 @@ let outputChannel: vscode.OutputChannel;
 let communicationService: any | null = null;
 let toolRelayService: any | null = null;
 
-export function activate(context: vscode.ExtensionContext) {
-  outputChannel = vscode.window.createOutputChannel("ValorIDE");
-  context.subscriptions.push(outputChannel);
+async function initializeDeferredStartupServices(
+  context: vscode.ExtensionContext,
+  workspaceRoot: string,
+): Promise<void> {
+  const deferredStartedAt = Date.now();
 
-  ErrorService.initialize();
-  Logger.initialize(outputChannel);
+  await setTimeoutPromise(0);
 
-  // Initialize PromptService (load system.json, thorapi-catalog.json, swarm-rules.json)
-  const workspaceRoot =
-    vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd();
   void initializePromptService(workspaceRoot, outputChannel)
     .then(() => {
       Logger.log("PromptService initialized successfully");
@@ -77,7 +76,6 @@ export function activate(context: vscode.ExtensionContext) {
       Logger.log(`PromptService initialization failed: ${error}`);
     });
 
-  // Initialize MemoryBankLoader (load .valoride/memorybank/)
   void initializeMemoryBankLoader(workspaceRoot, outputChannel)
     .then(() => {
       Logger.log("MemoryBankLoader initialized successfully");
@@ -86,7 +84,6 @@ export function activate(context: vscode.ExtensionContext) {
       Logger.log(`MemoryBankLoader initialization failed: ${error}`);
     });
 
-  // Initialize LLMPromptService (load base prompt + manual overrides)
   void (async () => {
     try {
       const { apiConfiguration, selectedLlmDetails } =
@@ -127,7 +124,6 @@ export function activate(context: vscode.ExtensionContext) {
     }
   })();
 
-  // Initialize LLMContextInjector (synthesize all prompt layers)
   void initializeLLMContextInjector(outputChannel)
     .then(() => {
       Logger.log("LLMContextInjector initialized successfully");
@@ -136,33 +132,47 @@ export function activate(context: vscode.ExtensionContext) {
       Logger.log(`LLMContextInjector initialization failed: ${error}`);
     });
 
-  // Initialize SwarmOrchestrator (Supervisor agent for task routing)
   initializeSwarmOrchestrator(outputChannel);
   Logger.log("SwarmOrchestrator initialized successfully");
 
-  // Initialize ThorAPIGeneratorService (6-stage app generation)
   initializeThorAPIGeneratorService(workspaceRoot, outputChannel);
   Logger.log("ThorAPIGeneratorService initialized successfully");
 
-  // Initialize ToolRankingEngine (Auto-rank tools by relevance)
   initializeToolRankingEngine(outputChannel);
   Logger.log("ToolRankingEngine initialized successfully");
 
-  // Initialize BrowserErrorCapture (Console error + auto-fix)
   initializeBrowserErrorCapture(workspaceRoot, outputChannel);
   Logger.log("BrowserErrorCapture initialized successfully");
 
-  // Initialize SwarmPromptBroadcaster (Real-time prompt broadcast)
   initializeSwarmPromptBroadcaster(outputChannel);
   Logger.log("SwarmPromptBroadcaster initialized successfully");
 
-  // Initialize ThorAPIModelRegistry (Auto-discover models/services)
   initializeThorAPIModelRegistry(workspaceRoot, outputChannel);
   Logger.log("ThorAPIModelRegistry initialized successfully");
 
-  // Initialize RatingService (Prompt self-improvement)
   initializeRatingService(outputChannel);
   Logger.log("RatingService initialized successfully");
+
+  Logger.log(
+    `Deferred startup services scheduled in ${Date.now() - deferredStartedAt}ms`,
+  );
+}
+
+export function activate(context: vscode.ExtensionContext) {
+  const activationStartedAt = Date.now();
+  outputChannel = vscode.window.createOutputChannel("ValorIDE");
+  context.subscriptions.push(outputChannel);
+
+  ErrorService.initialize();
+  Logger.initialize(outputChannel);
+
+  const workspaceRoot =
+    vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd();
+  void initializeDeferredStartupServices(context, workspaceRoot).catch(
+    (error) => {
+      Logger.log(`Deferred startup services failed: ${String(error)}`);
+    },
+  );
 
   // Initialize StatusBarService (Token tracking & status display)
   initializeStatusBarService(context);
@@ -180,7 +190,9 @@ export function activate(context: vscode.ExtensionContext) {
     ),
   );
 
-  Logger.log("ValorIDE extension activated");
+  Logger.log(
+    `ValorIDE extension activated in ${Date.now() - activationStartedAt}ms`,
+  );
 
   // Initialize startup authentication restoration in background
   void (async () => {
@@ -290,14 +302,13 @@ export function activate(context: vscode.ExtensionContext) {
     IS_DEV && IS_DEV === "true",
   );
 
-  // Ensure our Activity Bar container is visible, then focus our view
-  // This helps recover if the container was hidden from prior layout changes
-  void vscode.commands.executeCommand(
-    "workbench.view.extension.valoride-activitybar",
-  );
-  // Proactively reveal the sidebar view once after activation
-  // This helps surface the Activity Bar icon if the container was hidden/cached
-  void vscode.commands.executeCommand(`${WebviewProvider.sideBarId}.focus`);
+  void maybeRevealValorIDESidebarOnStartup(
+    context,
+    WebviewProvider.sideBarId,
+    (message) => Logger.log(message),
+  ).catch((error) => {
+    Logger.log(`Startup sidebar reveal failed: ${String(error)}`);
+  });
 
   context.subscriptions.push(
     vscode.commands.registerCommand(

--- a/src/startupActivation.test.ts
+++ b/src/startupActivation.test.ts
@@ -1,0 +1,64 @@
+import { expect } from "chai";
+import {
+  normalizeStartupRevealMode,
+  revealValorIDESidebar,
+  shouldRevealValorIDESidebarOnStartup,
+} from "./startupActivation";
+
+describe("startupActivation", () => {
+  describe("normalizeStartupRevealMode", () => {
+    it("defaults unknown values to never", () => {
+      expect(normalizeStartupRevealMode(undefined)).to.equal("never");
+      expect(normalizeStartupRevealMode("sometimes")).to.equal("never");
+    });
+
+    it("keeps supported reveal modes", () => {
+      expect(normalizeStartupRevealMode("never")).to.equal("never");
+      expect(normalizeStartupRevealMode("firstInstall")).to.equal(
+        "firstInstall",
+      );
+      expect(normalizeStartupRevealMode("always")).to.equal("always");
+    });
+  });
+
+  describe("shouldRevealValorIDESidebarOnStartup", () => {
+    it("does not reveal for returning firstInstall sessions", () => {
+      expect(shouldRevealValorIDESidebarOnStartup("firstInstall", true)).to.equal(
+        false,
+      );
+    });
+
+    it("reveals for firstInstall sessions that have not completed reveal", () => {
+      expect(
+        shouldRevealValorIDESidebarOnStartup("firstInstall", false),
+      ).to.equal(true);
+    });
+
+    it("honors never and always modes", () => {
+      expect(shouldRevealValorIDESidebarOnStartup("never", false)).to.equal(
+        false,
+      );
+      expect(shouldRevealValorIDESidebarOnStartup("always", true)).to.equal(
+        true,
+      );
+    });
+  });
+
+  describe("revealValorIDESidebar", () => {
+    it("reveals the activity bar before focusing the sidebar provider", async () => {
+      const calls: string[] = [];
+      const commands = {
+        executeCommand: async (command: string) => {
+          calls.push(command);
+        },
+      };
+
+      await revealValorIDESidebar(commands, "valoride-dev.SidebarProvider");
+
+      expect(calls).to.deep.equal([
+        "workbench.view.extension.valoride-activitybar",
+        "valoride-dev.SidebarProvider.focus",
+      ]);
+    });
+  });
+});

--- a/src/startupActivation.ts
+++ b/src/startupActivation.ts
@@ -1,0 +1,60 @@
+import * as vscode from "vscode";
+
+export const STARTUP_REVEAL_STATE_KEY = "valoride.startupReveal.completed";
+
+export type StartupRevealMode = "never" | "firstInstall" | "always";
+
+export function normalizeStartupRevealMode(value: unknown): StartupRevealMode {
+  if (value === "always" || value === "never" || value === "firstInstall") {
+    return value;
+  }
+
+  return "never";
+}
+
+export function shouldRevealValorIDESidebarOnStartup(
+  mode: StartupRevealMode,
+  startupRevealCompleted: boolean,
+): boolean {
+  if (mode === "always") {
+    return true;
+  }
+
+  if (mode === "firstInstall") {
+    return !startupRevealCompleted;
+  }
+
+  return false;
+}
+
+export async function revealValorIDESidebar(
+  commands: Pick<typeof vscode.commands, "executeCommand">,
+  sideBarId: string,
+): Promise<void> {
+  await commands.executeCommand("workbench.view.extension.valoride-activitybar");
+  await commands.executeCommand(`${sideBarId}.focus`);
+}
+
+export async function maybeRevealValorIDESidebarOnStartup(
+  context: vscode.ExtensionContext,
+  sideBarId: string,
+  logger: (message: string) => void,
+): Promise<void> {
+  const mode = normalizeStartupRevealMode(
+    vscode.workspace
+      .getConfiguration("valoride")
+      .get<StartupRevealMode>("startupReveal"),
+  );
+  const startupRevealCompleted = Boolean(
+    context.globalState.get(STARTUP_REVEAL_STATE_KEY),
+  );
+
+  if (!shouldRevealValorIDESidebarOnStartup(mode, startupRevealCompleted)) {
+    logger(`Startup sidebar reveal skipped; mode=${mode}`);
+    return;
+  }
+
+  await revealValorIDESidebar(vscode.commands, sideBarId);
+  await context.globalState.update(STARTUP_REVEAL_STATE_KEY, true);
+  logger(`Startup sidebar reveal completed; mode=${mode}`);
+}


### PR DESCRIPTION
## Summary
- stop forcing the ValorIDE Activity Bar and sidebar focus during normal startup
- add an opt-in `valoride.startupReveal` mode with `never`, `firstInstall`, and `always` policies
- defer heavier startup service scheduling until after the light activation path returns and log activation/deferred timing
- add unit coverage for startup reveal policy and explicit reveal command ordering

## Validation
- `git diff --check` passed
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` passed
- `yarn run check-types` could not complete because this fresh worktree has no installed dependencies and `yarn install --frozen-lockfile` reports the existing lockfile needs updates before install can proceed

Related: ValkyrLabs/ValkyrAI#2863