### PR TITLE
fix(startup): stop ValorIDE from stealing focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "llama"
   ],
   "activationEvents": [
-    "onStartupFinished",
     "onViewContainer:valoride-activitybar"
   ],
   "main": "./dist/extension.js",

--- a/src/extension.js
+++ b/src/extension.js
@@ -208,12 +208,6 @@ export function activate(context) {
     // Initialize test mode and set dev mode context
     context.subscriptions.push(...initializeTestMode(context, sidebarWebview));
     vscode.commands.executeCommand("setContext", "valoride.isDevMode", IS_DEV && IS_DEV === "true");
-    // Ensure our Activity Bar container is visible, then focus our view
-    // This helps recover if the container was hidden from prior layout changes
-    void vscode.commands.executeCommand("workbench.view.extension.valoride-activitybar");
-    // Proactively reveal the sidebar view once after activation
-    // This helps surface the Activity Bar icon if the container was hidden/cached
-    void vscode.commands.executeCommand(`${WebviewProvider.sideBarId}.focus`);
     context.subscriptions.push(vscode.commands.registerCommand("valoride.plusButtonClicked", async (webview) => {
         const openChat = async (instance) => {
             await instance?.controller.clearTask();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -290,15 +290,6 @@ export function activate(context: vscode.ExtensionContext) {
     IS_DEV && IS_DEV === "true",
   );
 
-  // Ensure our Activity Bar container is visible, then focus our view
-  // This helps recover if the container was hidden from prior layout changes
-  void vscode.commands.executeCommand(
-    "workbench.view.extension.valoride-activitybar",
-  );
-  // Proactively reveal the sidebar view once after activation
-  // This helps surface the Activity Bar icon if the container was hidden/cached
-  void vscode.commands.executeCommand(`${WebviewProvider.sideBarId}.focus`);
-
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "valoride.plusButtonClicked",

--- a/src/test/suite/startupBehavior.test.js
+++ b/src/test/suite/startupBehavior.test.js
@@ -2,17 +2,17 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const promises_1 = require("fs/promises");
 const mocha_1 = require("mocha");
-const path_1 = require("path");
+const path = require("path");
 require("should");
-const repoRoot = path_1.default.join(__dirname, "..", "..", "..");
+const repoRoot = path.join(__dirname, "..", "..", "..");
 (0, mocha_1.describe)("ValorIDE startup behavior", () => {
     (0, mocha_1.it)("does not activate on every VS Code startup", async () => {
-        const packageJSON = JSON.parse(await (0, promises_1.readFile)(path_1.default.join(repoRoot, "package.json"), "utf8"));
+        const packageJSON = JSON.parse(await (0, promises_1.readFile)(path.join(repoRoot, "package.json"), "utf8"));
         packageJSON.activationEvents.should.not.containEql("onStartupFinished");
         packageJSON.activationEvents.should.containEql("onViewContainer:valoride-activitybar");
     });
     (0, mocha_1.it)("does not force the activity bar or sidebar focus during activation", async () => {
-        const source = await (0, promises_1.readFile)(path_1.default.join(repoRoot, "src", "extension.ts"), "utf8");
+        const source = await (0, promises_1.readFile)(path.join(repoRoot, "src", "extension.ts"), "utf8");
         const startupActivationBody = source.slice(source.indexOf("export function activate"), source.indexOf("context.subscriptions.push("));
         startupActivationBody.should.not.containEql("workbench.view.extension.valoride-activitybar");
         startupActivationBody.should.not.containEql("WebviewProvider.sideBarId}.focus");

--- a/src/test/suite/startupBehavior.test.js
+++ b/src/test/suite/startupBehavior.test.js
@@ -1,0 +1,21 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const promises_1 = require("fs/promises");
+const mocha_1 = require("mocha");
+const path_1 = require("path");
+require("should");
+const repoRoot = path_1.default.join(__dirname, "..", "..", "..");
+(0, mocha_1.describe)("ValorIDE startup behavior", () => {
+    (0, mocha_1.it)("does not activate on every VS Code startup", async () => {
+        const packageJSON = JSON.parse(await (0, promises_1.readFile)(path_1.default.join(repoRoot, "package.json"), "utf8"));
+        packageJSON.activationEvents.should.not.containEql("onStartupFinished");
+        packageJSON.activationEvents.should.containEql("onViewContainer:valoride-activitybar");
+    });
+    (0, mocha_1.it)("does not force the activity bar or sidebar focus during activation", async () => {
+        const source = await (0, promises_1.readFile)(path_1.default.join(repoRoot, "src", "extension.ts"), "utf8");
+        const startupActivationBody = source.slice(source.indexOf("export function activate"), source.indexOf("context.subscriptions.push("));
+        startupActivationBody.should.not.containEql("workbench.view.extension.valoride-activitybar");
+        startupActivationBody.should.not.containEql("WebviewProvider.sideBarId}.focus");
+    });
+});
+//# sourceMappingURL=startupBehavior.test.js.map

--- a/src/test/suite/startupBehavior.test.ts
+++ b/src/test/suite/startupBehavior.test.ts
@@ -1,6 +1,6 @@
 import { readFile } from "fs/promises";
 import { describe, it } from "mocha";
-import path from "path";
+import * as path from "path";
 import "should";
 
 const repoRoot = path.join(__dirname, "..", "..", "..");

--- a/src/test/suite/startupBehavior.test.ts
+++ b/src/test/suite/startupBehavior.test.ts
@@ -1,0 +1,37 @@
+import { readFile } from "fs/promises";
+import { describe, it } from "mocha";
+import path from "path";
+import "should";
+
+const repoRoot = path.join(__dirname, "..", "..", "..");
+
+describe("ValorIDE startup behavior", () => {
+  it("does not activate on every VS Code startup", async () => {
+    const packageJSON = JSON.parse(
+      await readFile(path.join(repoRoot, "package.json"), "utf8"),
+    );
+
+    packageJSON.activationEvents.should.not.containEql("onStartupFinished");
+    packageJSON.activationEvents.should.containEql(
+      "onViewContainer:valoride-activitybar",
+    );
+  });
+
+  it("does not force the activity bar or sidebar focus during activation", async () => {
+    const source = await readFile(
+      path.join(repoRoot, "src", "extension.ts"),
+      "utf8",
+    );
+    const startupActivationBody = source.slice(
+      source.indexOf("export function activate"),
+      source.indexOf("context.subscriptions.push("),
+    );
+
+    startupActivationBody.should.not.containEql(
+      "workbench.view.extension.valoride-activitybar",
+    );
+    startupActivationBody.should.not.containEql(
+      "WebviewProvider.sideBarId}.focus",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- remove startup-finished activation so ValorIDE does not activate on every VS Code launch
- stop activation from forcing the ValorIDE activity bar and sidebar into focus
- add startup behavior regression tests for activation events and focus commands

Refs ValkyrLabs/ValkyrAI#2863.

## Verification
- PASS: node static assertions for activation events and startup focus commands
- BLOCKED: npm run compile-tests (missing installed type packages; npm ci unavailable because repo has yarn.lock but no package-lock)
- BLOCKED: npm run check-types (same missing dependency install baseline)
- BLOCKED: yarn install --frozen-lockfile (lockfile wants update)