### PR TITLE
test(llm): cover ThorAPI prompt fallback guards

### DIFF
--- a/src/services/__tests__/llmPromptService.test.ts
+++ b/src/services/__tests__/llmPromptService.test.ts
@@ -86,6 +86,38 @@ describe("LLMPromptService", () => {
     expect(service.getSelectedPrompt()?.source).toBe("fallback");
   });
 
+  it("falls back locally when ThorAPI returns a prompt without an initial prompt body", async () => {
+    const workspaceRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "valoride-prompt-empty-remote-test-"),
+    );
+    const promptDir = path.join(workspaceRoot, ".valoride", "prompts");
+    fs.mkdirSync(promptDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(promptDir, "system.json"),
+      JSON.stringify({ name: "Empty Remote Fallback Prompt", sections: [] }),
+    );
+    service = new LLMPromptService(workspaceRoot, mockLogger);
+    const client: LlmDetailsClient = {
+      query: vi.fn().mockResolvedValue([
+        {
+          id: "empty-remote-prompt",
+          name: "Empty Remote Prompt",
+          tags: ["typescript", "nodejs"],
+        },
+      ]),
+    };
+
+    await service.initialize(client);
+
+    expect(service.getSelectedPrompt()).toMatchObject({
+      source: "fallback",
+      name: "Empty Remote Fallback Prompt",
+    });
+    expect(mockLogger.appendLine).toHaveBeenCalledWith(
+      expect.stringContaining("has no initialPrompt"),
+    );
+  });
+
   it("falls back locally when the ThorAPI LLMDetails query fails offline", async () => {
     const workspaceRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), "valoride-prompt-offline-test-"),

--- a/src/services/__tests__/llmPromptService.test.ts
+++ b/src/services/__tests__/llmPromptService.test.ts
@@ -86,6 +86,33 @@ describe("LLMPromptService", () => {
     expect(service.getSelectedPrompt()?.source).toBe("fallback");
   });
 
+  it("falls back locally when the ThorAPI LLMDetails query fails offline", async () => {
+    const workspaceRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "valoride-prompt-offline-test-"),
+    );
+    const promptDir = path.join(workspaceRoot, ".valoride", "prompts");
+    fs.mkdirSync(promptDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(promptDir, "system.json"),
+      JSON.stringify({ name: "Offline Fallback Prompt", sections: [] }),
+    );
+    service = new LLMPromptService(workspaceRoot, mockLogger);
+    const client: LlmDetailsClient = {
+      query: vi.fn().mockRejectedValue(new Error("network unavailable")),
+    };
+
+    await service.initialize(client);
+
+    expect(client.query).toHaveBeenCalled();
+    expect(service.getSelectedPrompt()).toMatchObject({
+      source: "fallback",
+      name: "Offline Fallback Prompt",
+    });
+    expect(mockLogger.appendLine).toHaveBeenCalledWith(
+      expect.stringContaining("ThorAPI load failed"),
+    );
+  });
+
   it("applies manual selection overrides from UI", () => {
     service.applyManualSelection({
       llmDetailsId: "prompt-1",
@@ -171,5 +198,35 @@ describe("LLMPromptService", () => {
       promptType: "APPEND",
       tags: ["typescript", "thorapi", "production"],
     });
+  });
+
+  it("rejects unauthenticated ThorAPI LLMDetails queries without calling the API", async () => {
+    const get = vi.fn();
+    vi.mocked(axios.create).mockReturnValue({ get } as any);
+
+    const client = new ThorApiLlmDetailsClient(undefined, "https://api.test/v1");
+
+    await expect(
+      client.query({ tags: ["typescript"], limit: 1 }),
+    ).rejects.toThrow("requires signed-in auth");
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("normalizes configured ValkyrAI hosts to exactly one /v1 API base", async () => {
+    const get = vi.fn().mockResolvedValue({ data: [] });
+    const create = vi.mocked(axios.create);
+    create.mockReturnValue({ get } as any);
+
+    new ThorApiLlmDetailsClient("token", "https://api.test");
+    new ThorApiLlmDetailsClient("token", "https://api.test/v1");
+
+    expect(create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ baseURL: "https://api.test/v1" }),
+    );
+    expect(create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ baseURL: "https://api.test/v1" }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Add LLMPromptService coverage for offline ThorAPI fallback to local prompts
- Assert unauthenticated LLMDetails clients fail closed without API calls
- Cover ValkyrAI host normalization so startup clients target exactly one /v1 base

## Verification
- NODE_PATH=/Users/valklaw/.openclaw/workspace/valoride-2985-20260605-fresh/node_modules ../valoride-2985-20260605-fresh/node_modules/.bin/vitest run src/services/__tests__/llmPromptService.test.ts

Related ValkyrAI issue: ValkyrLabs/ValkyrAI#2985