### PR TITLE
feat(prompts): query ThorAPI LLMDetails on startup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ import { initializeThorAPIModelRegistry } from "./services/thorapiModelRegistry"
 import { initializeRatingService } from "./services/ratingService";
 import { initializeStatusBarService } from "./services/StatusBarService";
 import {
+  createExtensionHostLLMDetailsService,
   initializeLLMPromptService,
   SelectedPrompt,
 } from "./services/llmPromptService";
@@ -104,7 +105,7 @@ export function activate(context: vscode.ExtensionContext) {
       await initializeLLMPromptService(
         workspaceRoot,
         outputChannel,
-        undefined,
+        createExtensionHostLLMDetailsService(context, outputChannel),
         manualSelection,
       );
       Logger.log("LLMPromptService initialized successfully");

--- a/src/services/__tests__/llmPromptService.test.ts
+++ b/src/services/__tests__/llmPromptService.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { LLMPromptService } from "../llmPromptService";
+import {
+  initializeLLMPromptService,
+  LLMPromptService,
+  selectBestLlmDetailsPrompt,
+} from "../llmPromptService";
 import * as vscode from "vscode";
 
 describe("LLMPromptService", () => {
@@ -33,5 +37,86 @@ describe("LLMPromptService", () => {
     expect(selected?.name).toBe("Test Prompt");
     expect(selected?.mode).toBe("APPEND");
     expect(selected?.tags).toContain("app-gen");
+  });
+
+  it("loads a matching ThorAPI LLMDetails prompt from the injected extension service", async () => {
+    const queries: any[] = [];
+    service = new LLMPromptService(process.cwd(), mockLogger);
+
+    await service.initialize({
+      async query(input) {
+        queries.push(input);
+        return {
+          id: "llm-1",
+          name: "ThorAPI TypeScript Prompt",
+          initialPrompt: "Use the generated ThorAPI clients.",
+          promptType: "SYSTEM",
+          tags: ["typescript", "thorapi", "system"],
+          ratingScore: 4.9,
+        };
+      },
+    });
+
+    expect(queries).toHaveLength(1);
+    expect(queries[0].tags).toContain("typescript");
+    const selected = service.getSelectedPrompt();
+    expect(selected?.source).toBe("thorapi");
+    expect(selected?.llmDetailsId).toBe("llm-1");
+    expect(selected?.prompt).toBe("Use the generated ThorAPI clients.");
+  });
+
+  it("keeps manual selection from querying ThorAPI during global startup", async () => {
+    const query = vi.fn();
+
+    await initializeLLMPromptService(
+      process.cwd(),
+      mockLogger,
+      { query },
+      {
+        source: "thorapi",
+        llmDetailsId: "manual-1",
+        name: "Manual Prompt",
+        prompt: "Pinned by user.",
+        mode: "APPEND",
+        tags: ["manual"],
+        stackSpecific: true,
+      },
+    );
+
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("selects the best accessible prompt by tag match and rating", () => {
+    const selected = selectBestLlmDetailsPrompt(
+      {
+        content: [
+          {
+            id: "blocked-premium",
+            name: "Premium",
+            initialPrompt: "Premium prompt",
+            tags: ["typescript", "thorapi"],
+            ratingScore: 5,
+            isPremium: true,
+          },
+          {
+            id: "generic",
+            name: "Generic",
+            initialPrompt: "Generic prompt",
+            tags: ["system"],
+            ratingScore: 4.8,
+          },
+          {
+            id: "stack",
+            name: "Stack",
+            initialPrompt: "Stack prompt",
+            tags: "typescript,thorapi,system",
+            ratingScore: 4.2,
+          },
+        ],
+      },
+      ["typescript", "thorapi", "system"],
+    );
+
+    expect(selected?.id).toBe("stack");
   });
 });

--- a/src/services/llmPromptService.ts
+++ b/src/services/llmPromptService.ts
@@ -1,6 +1,8 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
+import { getAllExtensionState, getSecret } from "@core/storage/state";
+import { normalizeValkyraiHost } from "@utils/serverValkyraiHost";
 
 /**
  * LLMPromptService — ThorAPI-FIRST prompt loading
@@ -33,12 +35,38 @@ export interface ProjectStack {
   isGenerated: boolean;
 }
 
+export interface LLMDetailsQuery {
+  tags: string[];
+  stack: ProjectStack;
+  limit: number;
+}
+
+export interface LLMDetailsPromptCandidate {
+  id?: string;
+  name?: string;
+  initialPrompt?: string;
+  prompt?: string;
+  systemPrompt?: string;
+  promptType?: "SYSTEM" | "APPEND" | string;
+  tags?: string[] | string;
+  ratingScore?: number;
+  rating?: number;
+  updatedDate?: string;
+  lastModifiedDate?: string;
+  isPremium?: boolean;
+  accessStatus?: string;
+}
+
+export interface LLMDetailsPromptService {
+  query(input: LLMDetailsQuery): Promise<LLMDetailsPromptCandidate | null>;
+}
+
 export class LLMPromptService {
   private workspaceRoot: string;
   private logger: vscode.OutputChannel;
   private selectedPrompt: SelectedPrompt | null = null;
   private projectStack: ProjectStack | null = null;
-  private llmDetailsService: any = null; // Will be injected from webview
+  private llmDetailsService: LLMDetailsPromptService | null = null;
 
   constructor(workspaceRoot: string, logger: vscode.OutputChannel) {
     this.workspaceRoot = workspaceRoot;
@@ -48,7 +76,7 @@ export class LLMPromptService {
   /**
    * Initialize — detect project stack and attempt ThorAPI load
    */
-  async initialize(llmDetailsService?: any): Promise<void> {
+  async initialize(llmDetailsService?: LLMDetailsPromptService): Promise<void> {
     this.logger.appendLine("[LLMPromptService] Initializing...");
 
     try {
@@ -181,8 +209,8 @@ export class LLMPromptService {
           llmDetailsId: llmDetails.id,
           name: llmDetails.name,
           prompt: llmDetails.initialPrompt,
-          mode: llmDetails.promptType || "SYSTEM",
-          tags: llmDetails.tags || [],
+          mode: normalizePromptMode(llmDetails.promptType),
+          tags: normalizeTags(llmDetails.tags),
           stackSpecific: true,
         };
         this.logger.appendLine(
@@ -197,12 +225,19 @@ export class LLMPromptService {
   }
 
   /**
-   * Query LLMDetails by tags (stub for now)
+   * Query LLMDetails by tags through the injected extension-host client.
    */
-  private async queryLLMDetails(tags: string[]): Promise<any> {
-    // TODO: Implement via webview RTK Query once integrated
-    // return await llmDetailsService.query({ tags, sortBy: 'ratingScore', limit: 1 })
-    return null;
+  private async queryLLMDetails(
+    tags: string[],
+  ): Promise<LLMDetailsPromptCandidate | null> {
+    if (!this.llmDetailsService || !this.projectStack) {
+      return null;
+    }
+    return await this.llmDetailsService.query({
+      tags,
+      stack: this.projectStack,
+      limit: 1,
+    });
   }
 
   /**
@@ -366,19 +401,146 @@ export class LLMPromptService {
 
 export let llmPromptService: LLMPromptService | null = null;
 
+export function createExtensionHostLLMDetailsService(
+  context: vscode.ExtensionContext,
+  logger: vscode.OutputChannel,
+): LLMDetailsPromptService {
+  return {
+    async query(input: LLMDetailsQuery) {
+      const { apiConfiguration } = await getAllExtensionState(context);
+      if (!apiConfiguration?.valkyraiHost) {
+        logger.appendLine(
+          "[LLMPromptService] ThorAPI query skipped: ValkyrAI host is not configured",
+        );
+        return null;
+      }
+
+      const endpoint = new URL(
+        `${normalizeValkyraiHost(apiConfiguration.valkyraiHost)}/LlmDetails`,
+      );
+      endpoint.searchParams.set("limit", String(Math.max(input.limit, 10)));
+      endpoint.searchParams.set("sort", "ratingScore,desc");
+      for (const tag of input.tags) {
+        endpoint.searchParams.append("tags", tag);
+      }
+
+      const headers: Record<string, string> = {
+        Accept: "application/json",
+      };
+      const authToken =
+        apiConfiguration.valkyraiJwt || (await getSecret(context, "jwtToken"));
+      if (authToken) {
+        headers.Authorization = `Bearer ${authToken}`;
+      }
+
+      const response = await fetch(endpoint.toString(), { headers });
+      if (response.status === 401 || response.status === 403) {
+        logger.appendLine(
+          `[LLMPromptService] ThorAPI query denied by RBAC (${response.status}); using fallback prompt`,
+        );
+        return null;
+      }
+      if (!response.ok) {
+        throw new Error(`LlmDetails query failed with HTTP ${response.status}`);
+      }
+
+      const payload = await response.json();
+      return selectBestLlmDetailsPrompt(payload, input.tags);
+    },
+  };
+}
+
+export function selectBestLlmDetailsPrompt(
+  payload: unknown,
+  tags: string[],
+): LLMDetailsPromptCandidate | null {
+  const candidates = extractLlmDetails(payload).filter((candidate) => {
+    const prompt =
+      candidate.initialPrompt || candidate.prompt || candidate.systemPrompt;
+    if (!prompt || typeof prompt !== "string") {
+      return false;
+    }
+    const accessStatus = `${candidate.accessStatus || ""}`.toLowerCase();
+    return !candidate.isPremium && accessStatus !== "blocked";
+  });
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const queryTags = new Set(tags.map((tag) => tag.toLowerCase()));
+  return candidates
+    .map((candidate) => ({
+      candidate,
+      tagScore: normalizeTags(candidate.tags).filter((tag) =>
+        queryTags.has(tag.toLowerCase()),
+      ).length,
+      rating:
+        typeof candidate.ratingScore === "number"
+          ? candidate.ratingScore
+          : typeof candidate.rating === "number"
+            ? candidate.rating
+            : 0,
+      recency:
+        Date.parse(candidate.updatedDate || candidate.lastModifiedDate || "") ||
+        0,
+    }))
+    .sort(
+      (a, b) =>
+        b.tagScore - a.tagScore ||
+        b.rating - a.rating ||
+        b.recency - a.recency,
+    )[0].candidate;
+}
+
+function extractLlmDetails(payload: unknown): LLMDetailsPromptCandidate[] {
+  if (Array.isArray(payload)) {
+    return payload as LLMDetailsPromptCandidate[];
+  }
+  if (payload && typeof payload === "object") {
+    const record = payload as Record<string, unknown>;
+    for (const key of ["content", "items", "data", "results"]) {
+      if (Array.isArray(record[key])) {
+        return record[key] as LLMDetailsPromptCandidate[];
+      }
+    }
+  }
+  return [];
+}
+
+function normalizePromptMode(mode: unknown): "SYSTEM" | "APPEND" {
+  return mode === "APPEND" ? "APPEND" : "SYSTEM";
+}
+
+function normalizeTags(tags: unknown): string[] {
+  if (Array.isArray(tags)) {
+    return tags
+      .map((tag) => `${tag}`.trim())
+      .filter((tag) => tag.length > 0);
+  }
+  if (typeof tags === "string") {
+    return tags
+      .split(/[,\s]+/)
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+  }
+  return [];
+}
+
 /**
  * Initialize global LLMPromptService instance
  */
 export async function initializeLLMPromptService(
   workspaceRoot: string,
   logger: vscode.OutputChannel,
-  llmDetailsService?: any,
+  llmDetailsService?: LLMDetailsPromptService,
   manualSelection?: SelectedPrompt,
 ): Promise<void> {
   llmPromptService = new LLMPromptService(workspaceRoot, logger);
-  await llmPromptService.initialize(llmDetailsService);
   if (manualSelection) {
     llmPromptService.applyManualSelection(manualSelection);
+  } else {
+    await llmPromptService.initialize(llmDetailsService);
   }
 }
 


### PR DESCRIPTION
## Summary
- inject an extension-host LLMDetails query client during ValorIDE startup instead of passing `undefined`
- query the configured ValkyrAI host with stored JWT auth, classify RBAC denial as fallback-safe, and avoid logging tokens
- select the best accessible prompt by tag match, rating, and recency while preserving manual prompt overrides
- add focused LLMPromptService coverage for ThorAPI selection, manual override behavior, and premium-blocked filtering

Fixes ValkyrLabs/ValkyrAI#2985

## Verification
- PASS: `npx eslint src/extension.ts src/services/llmPromptService.ts src/services/__tests__/llmPromptService.test.ts`
- BLOCKED: `npx vitest run src/services/__tests__/llmPromptService.test.ts` fails before tests because baseline `vite.config.ts` has a parse error at line 72: `Unexpected "}"`
- BLOCKED: `npm run check-types -- --pretty false` was stopped after running silently for several minutes with no diagnostics

## Notes
- Installed dependencies with `yarn install --frozen-lockfile --ignore-scripts --ignore-engines` in the fresh worktree to run local checks.