### PR TITLE
test(llm): repair ThorAPI prompt coverage

### DIFF
--- a/src/services/__tests__/llmPromptService.test.ts
+++ b/src/services/__tests__/llmPromptService.test.ts
@@ -242,6 +242,10 @@ describe("LLMPromptService", () => {
 
     await expect(
       client.query({ tags: ["typescript", "thorapi"], limit: 1 }),
+    ).rejects.toThrow("requires signed-in auth");
+    expect(get).not.toHaveBeenCalled();
+  });
+
   it("rejects unauthenticated ThorAPI LLMDetails queries without calling the API", async () => {
     const get = vi.fn();
     vi.mocked(axios.create).mockReturnValue({ get } as any);
@@ -274,6 +278,8 @@ describe("LLMPromptService", () => {
     await expect(
       client.query({ tags: ["typescript", "thorapi"], limit: 1 }),
     ).rejects.toThrow("offline or unreachable");
+  });
+
   it("normalizes configured ValkyrAI hosts to exactly one /v1 API base", async () => {
     const get = vi.fn().mockResolvedValue({ data: [] });
     const create = vi.mocked(axios.create);


### PR DESCRIPTION
Summary
- Repair malformed LLMPromptService Vitest assertions for missing-auth and offline ThorAPI LLMDetails failures.
- Restore independent coverage for ValkyrAI host normalization in the ThorAPI LLMDetails client.
- Keeps the #2985 prompt marketplace slice reviewable without lockfile churn.

Verification
- npx vitest run src/services/__tests__/llmPromptService.test.ts (12 tests passed)
- yarn run check-types (fails on existing unrelated project-wide issues: startup reveal test mock typing, missing @testing-library/user-event, missing three, and BuyCredits test signature mismatches)

Refs ValkyrLabs/ValkyrAI#2985