### PR TITLE
fix(llm): use ThorAPI prompt response bodies

### DIFF
--- a/src/services/__tests__/llmPromptService.test.ts
+++ b/src/services/__tests__/llmPromptService.test.ts
@@ -65,6 +65,26 @@ describe("LLMPromptService", () => {
     expect(selected?.prompt).toBe("Use the generated ThorAPI clients.");
   });
 
+  it("accepts ThorAPI prompt fields when initialPrompt is absent", async () => {
+    service = new LLMPromptService(process.cwd(), mockLogger);
+
+    await service.initialize({
+      async query() {
+        return {
+          id: "llm-prompt-body",
+          name: "Prompt Body Field",
+          prompt: "Use the marketplace-selected prompt body.",
+          promptType: "SYSTEM",
+          tags: ["typescript", "system"],
+        };
+      },
+    });
+
+    expect(service.getSelectedPrompt()?.prompt).toBe(
+      "Use the marketplace-selected prompt body.",
+    );
+  });
+
   it("keeps manual selection from querying ThorAPI during global startup", async () => {
     const query = vi.fn();
 
@@ -118,5 +138,23 @@ describe("LLMPromptService", () => {
     );
 
     expect(selected?.id).toBe("stack");
+  });
+
+  it("selects systemPrompt candidates from paged ThorAPI responses", () => {
+    const selected = selectBestLlmDetailsPrompt(
+      {
+        content: [
+          {
+            id: "system-prompt",
+            name: "System Prompt",
+            systemPrompt: "Follow ThorAPI contracts first.",
+            tags: ["thorapi", "system"],
+          },
+        ],
+      },
+      ["thorapi", "system"],
+    );
+
+    expect(selected?.id).toBe("system-prompt");
   });
 });

--- a/src/services/llmPromptService.ts
+++ b/src/services/llmPromptService.ts
@@ -61,6 +61,8 @@ export interface LLMDetailsPromptService {
   query(input: LLMDetailsQuery): Promise<LLMDetailsPromptCandidate | null>;
 }
 
+const LLM_DETAILS_QUERY_TIMEOUT_MS = 5000;
+
 export class LLMPromptService {
   private workspaceRoot: string;
   private logger: vscode.OutputChannel;
@@ -204,11 +206,19 @@ export class LLMPromptService {
       const llmDetails = await this.queryLLMDetails(tags);
 
       if (llmDetails) {
+        const prompt = getPromptBody(llmDetails);
+        if (!prompt) {
+          this.logger.appendLine(
+            `[LLMPromptService] ThorAPI prompt ${llmDetails.id || llmDetails.name || "unknown"} did not include prompt text`,
+          );
+          return;
+        }
+
         this.selectedPrompt = {
           source: "thorapi",
           llmDetailsId: llmDetails.id,
-          name: llmDetails.name,
-          prompt: llmDetails.initialPrompt,
+          name: llmDetails.name || "ThorAPI LLMDetails prompt",
+          prompt,
           mode: normalizePromptMode(llmDetails.promptType),
           tags: normalizeTags(llmDetails.tags),
           stackSpecific: true,
@@ -433,7 +443,27 @@ export function createExtensionHostLLMDetailsService(
         headers.Authorization = `Bearer ${authToken}`;
       }
 
-      const response = await fetch(endpoint.toString(), { headers });
+      const controller = new AbortController();
+      const timeout = setTimeout(
+        () => controller.abort(),
+        LLM_DETAILS_QUERY_TIMEOUT_MS,
+      );
+
+      let response: Response;
+      try {
+        response = await fetch(endpoint.toString(), {
+          headers,
+          signal: controller.signal,
+        });
+      } catch (error) {
+        logger.appendLine(
+          `[LLMPromptService] ThorAPI query unavailable (${classifyLlmDetailsQueryError(error)}); using fallback prompt`,
+        );
+        return null;
+      } finally {
+        clearTimeout(timeout);
+      }
+
       if (response.status === 401 || response.status === 403) {
         logger.appendLine(
           `[LLMPromptService] ThorAPI query denied by RBAC (${response.status}); using fallback prompt`,
@@ -455,8 +485,7 @@ export function selectBestLlmDetailsPrompt(
   tags: string[],
 ): LLMDetailsPromptCandidate | null {
   const candidates = extractLlmDetails(payload).filter((candidate) => {
-    const prompt =
-      candidate.initialPrompt || candidate.prompt || candidate.systemPrompt;
+    const prompt = getPromptBody(candidate);
     if (!prompt || typeof prompt !== "string") {
       return false;
     }
@@ -506,6 +535,24 @@ function extractLlmDetails(payload: unknown): LLMDetailsPromptCandidate[] {
     }
   }
   return [];
+}
+
+function getPromptBody(candidate: LLMDetailsPromptCandidate): string | null {
+  const prompt =
+    candidate.initialPrompt || candidate.prompt || candidate.systemPrompt;
+  return typeof prompt === "string" && prompt.trim().length > 0
+    ? prompt
+    : null;
+}
+
+function classifyLlmDetailsQueryError(error: unknown): string {
+  if (error instanceof Error) {
+    if (error.name === "AbortError") {
+      return "timeout";
+    }
+    return error.message || error.name;
+  }
+  return "network error";
 }
 
 function normalizePromptMode(mode: unknown): "SYSTEM" | "APPEND" {


### PR DESCRIPTION
## Summary
- keep ValorIDE startup wired to the extension-host ThorAPI LLMDetails query path when no manual prompt is selected
- accept ThorAPI prompt, systemPrompt, or initialPrompt fields so marketplace responses do not fall back unnecessarily
- add a bounded query timeout and fallback logging for unavailable LLMDetails calls
- cover prompt-body and paged systemPrompt selection behavior

## Verification
- PASS: git diff --check
- BLOCKED: npx vitest run src/services/__tests__/llmPromptService.test.ts (baseline vite.config.ts contains literal `...`, causing esbuild to fail at vite.config.ts:72 before tests load)

Closes ValkyrLabs/ValkyrAI#2985