### PR TITLE
test(prompt): guard startup LLMDetails client wiring

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,12 +36,11 @@ import { initializeRatingService } from "./services/ratingService";
 import { initializeStatusBarService } from "./services/StatusBarService";
 import { revealValorideSidebar } from "./services/startupReveal";
 import {
+  createStartupLlmDetailsClient,
   initializeLLMPromptService,
-  SelectedPrompt,
-  ThorApiLlmDetailsClient,
+  selectedPromptFromStoredLlmDetails,
 } from "./services/llmPromptService";
 import { getAllExtensionState, getSecret } from "./core/storage/state";
-import { SelectedLlmDetails } from "@shared/llm";
 import {
   getStartupRevealMode,
   shouldRevealSidebarOnStartup,
@@ -66,27 +65,18 @@ async function initializeWorkspaceLlmPromptService(
 ): Promise<void> {
   const { apiConfiguration, selectedLlmDetails } =
     await getAllExtensionState(context);
-  const manualSelection: SelectedPrompt | undefined = selectedLlmDetails
-    ? {
-        llmDetailsId: selectedLlmDetails.id,
-        name: selectedLlmDetails.name,
-        prompt: selectedLlmDetails.prompt,
-        mode: selectedLlmDetails.mode,
-        tags: selectedLlmDetails.tags,
-        source:
-          selectedLlmDetails.source === "fallback" ? "fallback" : "thorapi",
-        stackSpecific: true,
-      }
-    : undefined;
+  const manualSelection =
+    selectedPromptFromStoredLlmDetails(selectedLlmDetails);
   const authToken =
     authTokenOverride ??
     (await getSecret(context, "jwtToken")) ??
     apiConfiguration.valkyraiJwt ??
     apiConfiguration.valorideApiKey;
-  const llmDetailsClient =
-    authToken && !manualSelection
-      ? new ThorApiLlmDetailsClient(authToken, apiConfiguration.valkyraiHost)
-      : undefined;
+  const llmDetailsClient = createStartupLlmDetailsClient({
+    authToken,
+    valkyraiHost: apiConfiguration.valkyraiHost,
+    manualSelection,
+  });
 
   await initializeLLMPromptService(
     workspaceRoot,

--- a/src/services/__tests__/llmPromptService.test.ts
+++ b/src/services/__tests__/llmPromptService.test.ts
@@ -5,6 +5,8 @@ import {
   LlmDetailsClient,
   getLLMPromptService,
   ThorApiLlmDetailsClient,
+  createStartupLlmDetailsClient,
+  selectedPromptFromStoredLlmDetails,
 } from "../llmPromptService";
 import axios from "axios";
 import * as vscode from "vscode";
@@ -296,5 +298,48 @@ describe("LLMPromptService", () => {
       2,
       expect.objectContaining({ baseURL: "https://api.test/v1" }),
     );
+  });
+
+  it("creates the startup ThorAPI client from stored auth and configured host", async () => {
+    const get = vi.fn().mockResolvedValue({ data: [] });
+    const create = vi.mocked(axios.create);
+    create.mockReturnValue({ get } as any);
+
+    const client = createStartupLlmDetailsClient({
+      authToken: "stored-jwt",
+      valkyraiHost: "https://api.test",
+    });
+
+    expect(client).toBeInstanceOf(ThorApiLlmDetailsClient);
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: "https://api.test/v1",
+        headers: { Authorization: "Bearer stored-jwt" },
+      }),
+    );
+  });
+
+  it("suppresses startup ThorAPI queries when a manual prompt selection exists", () => {
+    const manualSelection = selectedPromptFromStoredLlmDetails({
+      id: "manual-llm-details",
+      name: "Pinned Team Prompt",
+      prompt: "Use this pinned prompt.",
+      mode: "APPEND",
+      tags: ["team-policy"],
+      source: "manual",
+    });
+
+    const client = createStartupLlmDetailsClient({
+      authToken: "stored-jwt",
+      valkyraiHost: "https://api.test",
+      manualSelection,
+    });
+
+    expect(client).toBeUndefined();
+    expect(manualSelection).toMatchObject({
+      llmDetailsId: "manual-llm-details",
+      source: "thorapi",
+      tags: ["team-policy"],
+    });
   });
 });

--- a/src/services/llmPromptService.ts
+++ b/src/services/llmPromptService.ts
@@ -37,6 +37,12 @@ export interface LlmDetailsClient {
   query(query: LlmDetailsQuery): Promise<LlmDetailsSummary[]>;
 }
 
+export interface StartupLlmPromptClientOptions {
+  authToken?: string;
+  valkyraiHost?: string;
+  manualSelection?: SelectedPrompt;
+}
+
 export interface ProjectStack {
   language: "java" | "python" | "nodejs" | "typescript" | "mixed" | "unknown";
   framework?: string;
@@ -581,3 +587,41 @@ export class ThorApiLlmDetailsClient implements LlmDetailsClient {
       .slice(0, query.limit ?? 1);
   }
 }
+
+export const selectedPromptFromStoredLlmDetails = (
+  selectedLlmDetails?: {
+    id: string;
+    name: string;
+    prompt: string;
+    mode: LlmPromptMode;
+    tags?: string[];
+    source?: "thorapi" | "fallback" | "manual";
+  } | null,
+): SelectedPrompt | undefined => {
+  if (!selectedLlmDetails) {
+    return undefined;
+  }
+
+  return {
+    llmDetailsId: selectedLlmDetails.id,
+    name: selectedLlmDetails.name,
+    prompt: selectedLlmDetails.prompt,
+    mode: selectedLlmDetails.mode,
+    tags: selectedLlmDetails.tags ?? [],
+    source:
+      selectedLlmDetails.source === "fallback" ? "fallback" : "thorapi",
+    stackSpecific: true,
+  };
+};
+
+export const createStartupLlmDetailsClient = ({
+  authToken,
+  valkyraiHost,
+  manualSelection,
+}: StartupLlmPromptClientOptions): LlmDetailsClient | undefined => {
+  if (!authToken || manualSelection) {
+    return undefined;
+  }
+
+  return new ThorApiLlmDetailsClient(authToken, valkyraiHost);
+};


### PR DESCRIPTION
## Summary
- Move ValorIDE startup LLMDetails prompt-client assembly into the prompt service so auth/manual-selection behavior is testable
- Keep startup wired to the stored ValkyrAI auth token and configured host when no manual prompt is pinned
- Add regression coverage proving stored auth creates a ThorAPI client and manual selection suppresses remote prompt queries

## Links
- Tracks ValkyrLabs/ValkyrAI#2985

## Verification
- npx vitest run src/services/__tests__/llmPromptService.test.ts
- npx eslint src/extension.ts src/services/llmPromptService.ts src/services/__tests__/llmPromptService.test.ts
- yarn run check-types (fails on existing unrelated repo-wide issues: startup reveal test generics, missing @testing-library/user-event, missing three, and existing webview test type mismatches)