### PR TITLE
feat(marketplace): add MCP purchase review

### DIFF
--- a/src/views/MonetizedServicesMarketplace.css
+++ b/src/views/MonetizedServicesMarketplace.css
@@ -58,6 +58,59 @@
   background: rgba(255, 68, 68, 0.3);
 }
 
+.notice-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  border-radius: 8px;
+  margin-bottom: 24px;
+}
+
+.notice-banner p {
+  margin: 0;
+  font-size: 14px;
+}
+
+.notice-banner button {
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.notice-success {
+  background: rgba(76, 175, 80, 0.12);
+  border: 1px solid rgba(76, 175, 80, 0.42);
+}
+
+.notice-success p {
+  color: #8ee59b;
+}
+
+.notice-success button {
+  background: rgba(76, 175, 80, 0.18);
+  border: 1px solid rgba(76, 175, 80, 0.38);
+  color: #8ee59b;
+}
+
+.notice-error {
+  background: rgba(255, 68, 68, 0.1);
+  border: 1px solid rgba(255, 68, 68, 0.4);
+}
+
+.notice-error p {
+  color: #ff8a8a;
+}
+
+.notice-error button {
+  background: rgba(255, 68, 68, 0.18);
+  border: 1px solid rgba(255, 68, 68, 0.38);
+  color: #ff8a8a;
+}
+
 .loading-state {
   text-align: center;
   padding: 60px 20px;
@@ -346,4 +399,118 @@
 .btn-reset:hover {
   background: rgba(100, 200, 255, 0.3);
   border-color: rgba(100, 200, 255, 0.6);
+}
+
+.marketplace-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(4, 8, 20, 0.72);
+}
+
+.marketplace-dialog {
+  width: min(620px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow: auto;
+  background: #11182e;
+  border: 1px solid rgba(100, 200, 255, 0.35);
+  border-radius: 8px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+  padding: 24px;
+}
+
+.dialog-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.dialog-kicker {
+  margin: 0 0 4px 0;
+  color: #64c8ff;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.dialog-header h2 {
+  margin: 0;
+  font-size: 24px;
+}
+
+.dialog-close {
+  width: 32px;
+  height: 32px;
+  border: 1px solid rgba(100, 200, 255, 0.28);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.dialog-description,
+.purchase-policy {
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.5;
+}
+
+.service-facts,
+.purchase-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+  margin: 18px 0;
+}
+
+.service-facts div,
+.purchase-summary div {
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(100, 200, 255, 0.15);
+  border-radius: 8px;
+}
+
+.service-facts dt,
+.purchase-summary span {
+  display: block;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+
+.service-facts dd,
+.purchase-summary strong {
+  margin: 0;
+  color: #fff;
+  font-size: 15px;
+}
+
+.trust-signal-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 18px 0;
+}
+
+.trust-signal-list span {
+  padding: 6px 10px;
+  background: rgba(100, 200, 255, 0.12);
+  border: 1px solid rgba(100, 200, 255, 0.22);
+  border-radius: 999px;
+  color: #9fdcff;
+  font-size: 12px;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 22px;
 }

--- a/src/views/MonetizedServicesMarketplace.tsx
+++ b/src/views/MonetizedServicesMarketplace.tsx
@@ -4,6 +4,12 @@ import {
   getMarketplaceServices,
   subscribeToService,
 } from "@thorapi/services/monetization/ServiceMonetizationService";
+import {
+  buildTrustSignals,
+  getEstimatedSpendLabel,
+  getCreatorDisplayName,
+  getServicePricingSummary,
+} from "./monetizedServicesMarketplaceUtils";
 import "./MonetizedServicesMarketplace.css";
 
 /**
@@ -14,6 +20,14 @@ export const MonetizedServicesMarketplace: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [subscribing, setSubscribing] = useState<string | null>(null);
+  const [selectedService, setSelectedService] =
+    useState<ManagedMcpService | null>(null);
+  const [purchaseService, setPurchaseService] =
+    useState<ManagedMcpService | null>(null);
+  const [notice, setNotice] = useState<{
+    tone: "success" | "error";
+    message: string;
+  } | null>(null);
   const [filterTier, setFilterTier] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<"newest" | "popular" | "price-low">(
     "newest",
@@ -39,18 +53,25 @@ export const MonetizedServicesMarketplace: React.FC = () => {
     }
   };
 
-  const handleSubscribe = async (serviceId: string) => {
-    setSubscribing(serviceId);
+  const handleSubscribe = async (service: ManagedMcpService) => {
+    setSubscribing(service.id);
+    setNotice(null);
 
     try {
-      await subscribeToService(serviceId, "PAY_AS_YOU_GO");
-      // Show success and refresh
-      alert("✓ Successfully subscribed!");
-      loadServices();
+      await subscribeToService(service.id, "PAY_AS_YOU_GO");
+      setNotice({
+        tone: "success",
+        message: `Subscribed to ${service.name}. You can now use it from connected MCP tools.`,
+      });
+      setPurchaseService(null);
+      await loadServices();
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Failed to subscribe";
-      alert(`✗ ${message}`);
+      setNotice({
+        tone: "error",
+        message,
+      });
     } finally {
       setSubscribing(null);
     }
@@ -98,6 +119,13 @@ export const MonetizedServicesMarketplace: React.FC = () => {
         <div className="error-banner">
           <p>{error}</p>
           <button onClick={loadServices}>Retry</button>
+        </div>
+      )}
+
+      {notice && (
+        <div className={`notice-banner notice-${notice.tone}`} role="status">
+          <p>{notice.message}</p>
+          <button onClick={() => setNotice(null)}>Dismiss</button>
         </div>
       )}
 
@@ -178,7 +206,9 @@ export const MonetizedServicesMarketplace: React.FC = () => {
               </div>
 
               <div className="creator-info">
-                <span className="creator-label">By: Creator</span>
+                <span className="creator-label">
+                  By: {getCreatorDisplayName(service)}
+                </span>
                 <span className="created-date">
                   {new Date(service.createdAt).toLocaleDateString()}
                 </span>
@@ -186,7 +216,7 @@ export const MonetizedServicesMarketplace: React.FC = () => {
 
               <div className="card-actions">
                 <button
-                  onClick={() => handleSubscribe(service.id)}
+                  onClick={() => setPurchaseService(service)}
                   disabled={subscribing === service.id}
                   className="btn btn-subscribe"
                 >
@@ -194,7 +224,12 @@ export const MonetizedServicesMarketplace: React.FC = () => {
                     ? "Subscribing..."
                     : "Subscribe Now"}
                 </button>
-                <button className="btn btn-details">Details →</button>
+                <button
+                  className="btn btn-details"
+                  onClick={() => setSelectedService(service)}
+                >
+                  Details →
+                </button>
               </div>
             </div>
           ))}
@@ -207,6 +242,131 @@ export const MonetizedServicesMarketplace: React.FC = () => {
           <button onClick={() => setFilterTier(null)} className="btn btn-reset">
             Reset Filters
           </button>
+        </div>
+      )}
+
+      {selectedService && (
+        <div className="marketplace-dialog-backdrop" role="presentation">
+          <section
+            className="marketplace-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-label={`${selectedService.name} service details`}
+          >
+            <div className="dialog-header">
+              <div>
+                <p className="dialog-kicker">Service profile</p>
+                <h2>{selectedService.name}</h2>
+              </div>
+              <button
+                className="dialog-close"
+                onClick={() => setSelectedService(null)}
+                aria-label="Close details"
+              >
+                ×
+              </button>
+            </div>
+            <p className="dialog-description">
+              {selectedService.description || "No description available"}
+            </p>
+            <dl className="service-facts">
+              <div>
+                <dt>Creator</dt>
+                <dd>{getCreatorDisplayName(selectedService)}</dd>
+              </div>
+              <div>
+                <dt>Pricing</dt>
+                <dd>{getServicePricingSummary(selectedService)}</dd>
+              </div>
+              <div>
+                <dt>Status</dt>
+                <dd>{selectedService.status}</dd>
+              </div>
+            </dl>
+            <div className="trust-signal-list">
+              {buildTrustSignals(selectedService).map((signal) => (
+                <span key={signal}>{signal}</span>
+              ))}
+            </div>
+            <div className="dialog-actions">
+              <button
+                className="btn btn-details"
+                onClick={() => setSelectedService(null)}
+              >
+                Close
+              </button>
+              <button
+                className="btn btn-subscribe"
+                onClick={() => {
+                  setPurchaseService(selectedService);
+                  setSelectedService(null);
+                }}
+              >
+                Review Purchase
+              </button>
+            </div>
+          </section>
+        </div>
+      )}
+
+      {purchaseService && (
+        <div className="marketplace-dialog-backdrop" role="presentation">
+          <section
+            className="marketplace-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-label={`Review ${purchaseService.name} purchase`}
+          >
+            <div className="dialog-header">
+              <div>
+                <p className="dialog-kicker">Purchase review</p>
+                <h2>{purchaseService.name}</h2>
+              </div>
+              <button
+                className="dialog-close"
+                onClick={() => setPurchaseService(null)}
+                aria-label="Close purchase review"
+              >
+                ×
+              </button>
+            </div>
+            <div className="purchase-summary">
+              <div>
+                <span>Price</span>
+                <strong>{getServicePricingSummary(purchaseService)}</strong>
+              </div>
+              <div>
+                <span>Estimated 100-call spend</span>
+                <strong>{getEstimatedSpendLabel(purchaseService)}</strong>
+              </div>
+              <div>
+                <span>Subscription</span>
+                <strong>Pay as you go</strong>
+              </div>
+            </div>
+            <p className="purchase-policy">
+              Charges are recorded through the ValkyrAI billing ledger. You can
+              stop using the service at any time, and support requests go to the
+              listed creator.
+            </p>
+            <div className="dialog-actions">
+              <button
+                className="btn btn-details"
+                onClick={() => setPurchaseService(null)}
+              >
+                Cancel
+              </button>
+              <button
+                className="btn btn-subscribe"
+                onClick={() => handleSubscribe(purchaseService)}
+                disabled={subscribing === purchaseService.id}
+              >
+                {subscribing === purchaseService.id
+                  ? "Subscribing..."
+                  : "Confirm Subscription"}
+              </button>
+            </div>
+          </section>
         </div>
       )}
     </div>

--- a/src/views/monetizedServicesMarketplaceUtils.test.ts
+++ b/src/views/monetizedServicesMarketplaceUtils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTrustSignals,
+  estimateMonthlyCreditSpend,
+  getCreatorDisplayName,
+  getEstimatedSpendLabel,
+  getServicePricingSummary,
+} from "./monetizedServicesMarketplaceUtils";
+import { ManagedMcpService } from "@thorapi/services/monetization/ServiceMonetizationService";
+
+const service = (
+  overrides: Partial<ManagedMcpService> = {},
+): ManagedMcpService => ({
+  id: "svc-1",
+  applicationId: "app-1",
+  name: "Revenue Assistant",
+  description: "Premium MCP service",
+  createdBy: "creator@valkyrlabs.com",
+  status: "MONETIZED",
+  pricingModel: "PER_CALL",
+  costPerCall: 7,
+  tierName: "PRO",
+  hideFromMarketplace: false,
+  isMonetized: true,
+  createdAt: "2026-06-14T00:00:00Z",
+  updatedAt: "2026-06-14T01:00:00Z",
+  ...overrides,
+});
+
+describe("monetized service marketplace helpers", () => {
+  it("derives creator display names without exposing full email addresses", () => {
+    expect(getCreatorDisplayName(service())).toBe("creator");
+    expect(getCreatorDisplayName(service({ createdBy: "" }))).toBe(
+      "Verified creator",
+    );
+  });
+
+  it("summarizes pricing and expected credit spend for purchase review", () => {
+    expect(getServicePricingSummary(service())).toBe("7 credits per call");
+    expect(estimateMonthlyCreditSpend(service(), 25)).toBe(175);
+    expect(getEstimatedSpendLabel(service(), 25)).toBe("175 credits");
+    expect(
+      getServicePricingSummary(
+        service({
+          pricingModel: "PER_MONTH",
+          costPerCall: undefined,
+          costPerMonth: 29,
+        }),
+      ),
+    ).toBe("$29.00 monthly");
+    expect(
+      getEstimatedSpendLabel(
+        service({ pricingModel: "PER_MONTH", costPerMonth: 29 }),
+      ),
+    ).toBe("Plan based");
+  });
+
+  it("builds trust signals from service status and tier", () => {
+    expect(buildTrustSignals(service())).toEqual([
+      "Monetized service",
+      "PRO tier",
+      "ValkyrAI billing ledger",
+      "Creator support required",
+    ]);
+  });
+});

--- a/src/views/monetizedServicesMarketplaceUtils.ts
+++ b/src/views/monetizedServicesMarketplaceUtils.ts
@@ -1,0 +1,56 @@
+import { ManagedMcpService } from "@thorapi/services/monetization/ServiceMonetizationService";
+
+export function getCreatorDisplayName(service: ManagedMcpService): string {
+  const creator = service.createdBy?.trim();
+  if (!creator) {
+    return "Verified creator";
+  }
+
+  if (creator.includes("@")) {
+    return creator.split("@")[0] || "Verified creator";
+  }
+
+  return creator;
+}
+
+export function getServicePricingSummary(service: ManagedMcpService): string {
+  if (service.pricingModel === "PER_MONTH" && service.costPerMonth) {
+    return `$${service.costPerMonth.toFixed(2)} monthly`;
+  }
+
+  if (service.costPerCall) {
+    return `${service.costPerCall} credits per call`;
+  }
+
+  return "Usage-based pricing";
+}
+
+export function estimateMonthlyCreditSpend(
+  service: ManagedMcpService,
+  expectedCalls = 100,
+): number | null {
+  if (service.pricingModel !== "PER_CALL" || !service.costPerCall) {
+    return null;
+  }
+
+  return Math.max(0, Math.round(service.costPerCall * expectedCalls));
+}
+
+export function getEstimatedSpendLabel(
+  service: ManagedMcpService,
+  expectedCalls = 100,
+): string {
+  const spend = estimateMonthlyCreditSpend(service, expectedCalls);
+  return spend === null ? "Plan based" : `${spend} credits`;
+}
+
+export function buildTrustSignals(service: ManagedMcpService): string[] {
+  const signals = [
+    service.status === "MONETIZED" ? "Monetized service" : "Published service",
+    service.tierName ? `${service.tierName} tier` : "Standard tier",
+    "ValkyrAI billing ledger",
+    "Creator support required",
+  ];
+
+  return signals;
+}


### PR DESCRIPTION
## Summary
- replace alert-based MCP service subscription with an in-webview purchase review sheet
- make Details open a service profile with creator, pricing, status, and trust signals
- keep subscribe success/failure in dismissible webview notices and add focused marketplace helper tests

## Links
- Tracks ValkyrLabs/ValkyrAI#2977

## Verification
- PASS: git diff --check
- BLOCKED: npx vitest run src/views/monetizedServicesMarketplaceUtils.test.ts (fresh worktree had no node_modules; install attempt failed with ENOSPC while linking dependencies)
- BLOCKED: npx eslint src/views/MonetizedServicesMarketplace.tsx src/views/monetizedServicesMarketplaceUtils.ts src/views/monetizedServicesMarketplaceUtils.test.ts (no local eslint config available without dependencies)
- BLOCKED: yarn install --ignore-scripts --ignore-engines --no-lockfile (ENOSPC while linking @babel/traverse source map)
- PARTIAL: tsc --noEmit --pretty false filtered for changed files only reported missing react/react-jsx-runtime/vitest packages after dependency install failed
