### PR TITLE
fix(package): guard VSIX release bloat

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,14 +2,21 @@
 .git/
 .gitignore
 .husky/
+.worktrees/
 .vscode/
 .DS_Store
 .valoride
 ValorIDE_docs/
+
 # ignore caches and build outputs
-**/dist/**
 **/.cache/**
+**/.turbo/**
+**/.vite/**
+**/coverage/**
+**/node_modules/**
 **/*.log
+**/*.map
+
 # Exclude source, tests, docs, configs, and build scripts
 src/
 test/
@@ -32,9 +39,11 @@ eslint.config.*
 *.md
 *.markdown
 *.vsix
-
-# Exclude node_modules except production dependencies (if not bundled)
-node_modules/
+out/
+webview-ui/
+packages/*/node_modules/
+packages/*/dist/
+packages/*/out/
 
 # Exclude other common unnecessary files
 *.swp
@@ -43,9 +52,7 @@ node_modules/
 *.tmp
 
 # Include only the built output and essential files
-!out/
 !dist/
-dist/**/*.map
 !extension.js
 !package.json
 !README.md

--- a/package.json
+++ b/package.json
@@ -536,6 +536,7 @@
     "test:webview": "cd webview-ui && yarn run test",
     "publish:marketplace": "vsce publish && ovsx publish",
     "publish:marketplace:prerelease": "vsce publish --pre-release && ovsx publish --pre-release",
+    "package:audit": "node src/utils/vsixPackageAudit.js",
     "prepare": "husky",
     "changeset": "changeset",
     "version-packages": "changeset version"

--- a/src/utils/vsixPackageAudit.js
+++ b/src/utils/vsixPackageAudit.js
@@ -1,0 +1,123 @@
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const DEFAULT_BUDGET = Object.freeze({
+  maxBytes: 75 * 1024 * 1024,
+  maxFiles: 8000,
+});
+
+const BLOCKED_PATH_PATTERNS = [
+  /(^|\/)\.worktrees(\/|$)/,
+  /(^|\/)node_modules(\/|$)/,
+  /(^|\/)webview-ui\/build(\/|$)/,
+  /(^|\/)packages\/[^/]+\/dist(\/|$)/,
+  /\.map$/i,
+  /\.vsix$/i,
+];
+
+function normalizeEntry(entry) {
+  if (typeof entry === "string") {
+    return { path: entry, bytes: 0 };
+  }
+
+  return {
+    path: String(entry.path || ""),
+    bytes: Number.isFinite(entry.bytes) ? entry.bytes : 0,
+  };
+}
+
+function auditEntries(entries, budget = DEFAULT_BUDGET) {
+  const normalizedEntries = entries.map(normalizeEntry).filter((entry) => entry.path);
+  const totalBytes = normalizedEntries.reduce((sum, entry) => sum + entry.bytes, 0);
+  const blockedEntries = normalizedEntries
+    .filter((entry) => BLOCKED_PATH_PATTERNS.some((pattern) => pattern.test(entry.path)))
+    .map((entry) => entry.path);
+  const oversized = totalBytes > budget.maxBytes;
+  const tooManyFiles = normalizedEntries.length > budget.maxFiles;
+
+  return {
+    ok: blockedEntries.length === 0 && !oversized && !tooManyFiles,
+    totalBytes,
+    totalFiles: normalizedEntries.length,
+    maxBytes: budget.maxBytes,
+    maxFiles: budget.maxFiles,
+    blockedEntries,
+    topFiles: normalizedEntries
+      .slice()
+      .sort((left, right) => right.bytes - left.bytes)
+      .slice(0, 50),
+    failures: [
+      ...blockedEntries.map((entry) => `blocked package entry: ${entry}`),
+      ...(oversized ? [`package size ${totalBytes} exceeds budget ${budget.maxBytes}`] : []),
+      ...(tooManyFiles
+        ? [`package file count ${normalizedEntries.length} exceeds budget ${budget.maxFiles}`]
+        : []),
+    ],
+  };
+}
+
+function parseUnzipListing(listing) {
+  return listing
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+\d{2}-\d{2}-\d{4}\s+\d{2}:\d{2}\s+(.+)$/);
+      if (!match) {
+        return null;
+      }
+      return { bytes: Number(match[1]), path: match[2] };
+    })
+    .filter(Boolean);
+}
+
+function readVsixEntries(vsixPath) {
+  const listing = execFileSync("unzip", ["-l", vsixPath], {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return parseUnzipListing(listing);
+}
+
+function auditVsix(vsixPath, budget = DEFAULT_BUDGET) {
+  const entries = readVsixEntries(vsixPath);
+  const audit = auditEntries(entries, budget);
+  const stat = fs.statSync(vsixPath);
+  return {
+    ...audit,
+    archiveBytes: stat.size,
+    vsixPath: path.resolve(vsixPath),
+  };
+}
+
+function printAudit(audit) {
+  console.log(JSON.stringify(audit, null, 2));
+  if (!audit.ok) {
+    console.error(audit.failures.join("\n"));
+  }
+}
+
+function runCli(argv = process.argv.slice(2)) {
+  const [vsixPath] = argv;
+  if (!vsixPath) {
+    console.error("Usage: node src/utils/vsixPackageAudit.js <extension.vsix>");
+    return 2;
+  }
+
+  const audit = auditVsix(vsixPath);
+  printAudit(audit);
+  return audit.ok ? 0 : 1;
+}
+
+if (require.main === module) {
+  process.exitCode = runCli();
+}
+
+module.exports = {
+  BLOCKED_PATH_PATTERNS,
+  DEFAULT_BUDGET,
+  auditEntries,
+  auditVsix,
+  parseUnzipListing,
+  runCli,
+};

--- a/src/utils/vsixPackageAudit.test.ts
+++ b/src/utils/vsixPackageAudit.test.ts
@@ -1,0 +1,53 @@
+import { auditEntries, parseUnzipListing } from "./vsixPackageAudit";
+
+describe("vsixPackageAudit", () => {
+  it("rejects accidental workspace, dependency, source map, and nested build artifacts", () => {
+    const audit = auditEntries([
+      "extension/dist/extension.js",
+      "extension/.worktrees/feature-llm-prompt-refresh/package.json",
+      "extension/webview-ui/build/assets/index.js",
+      "extension/packages/valor-cli/dist/index.js",
+      "extension/node_modules/@swc/core-darwin-arm64/swc.darwin-arm64.node",
+      "extension/dist/extension.js.map",
+    ]);
+
+    expect(audit.ok).toBe(false);
+    expect(audit.blockedEntries).toEqual([
+      "extension/.worktrees/feature-llm-prompt-refresh/package.json",
+      "extension/webview-ui/build/assets/index.js",
+      "extension/packages/valor-cli/dist/index.js",
+      "extension/node_modules/@swc/core-darwin-arm64/swc.darwin-arm64.node",
+      "extension/dist/extension.js.map",
+    ]);
+  });
+
+  it("fails release budgets before a bloated VSIX reaches publication", () => {
+    const audit = auditEntries(
+      [
+        { path: "extension/dist/extension.js", bytes: 50 },
+        { path: "extension/dist/webview/assets/index.js", bytes: 75 },
+      ],
+      { maxBytes: 100, maxFiles: 1 },
+    );
+
+    expect(audit.ok).toBe(false);
+    expect(audit.failures).toContain("package size 125 exceeds budget 100");
+    expect(audit.failures).toContain("package file count 2 exceeds budget 1");
+  });
+
+  it("parses unzip listings into package entries", () => {
+    const entries = parseUnzipListing(`
+Archive:  valoride-dev.vsix
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+     4096  06-14-2026 15:44   extension/dist/extension.js
+      512  06-14-2026 15:44   extension/package.json
+---------                     -------
+`);
+
+    expect(entries).toEqual([
+      { bytes: 4096, path: "extension/dist/extension.js" },
+      { bytes: 512, path: "extension/package.json" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary\n- tighten VSIX package exclusions for worktrees, nested dependencies, duplicate webview build output, source maps, and recursive VSIX artifacts\n- add a Node package audit entrypoint with size, file-count, blocked-entry, and top-file reporting\n- add Jest coverage for blocked entries, release budgets, and unzip manifest parsing\n\nRefs ValkyrLabs/ValkyrAI#2949\n\n## Verification\n- node smoke for src/utils/vsixPackageAudit.js passed\n- yarn jest src/utils/vsixPackageAudit.test.ts --runInBand could not run because this fresh worktree has no node_modules and jest is not installed\n