### PR TITLE
fix(mcp): route marketplace cards through hosted browser links

### DIFF
--- a/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceCard.test.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceCard.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import McpMarketplaceCard from "./McpMarketplaceCard";
+
+const mockPostMessage = vi.fn();
+
+vi.mock("@thorapi/utils/vscode", () => ({
+  vscode: {
+    postMessage: (...args: unknown[]) => mockPostMessage(...args),
+  },
+}));
+
+const baseItem = {
+  mcpId: "mcp-graymatter",
+  githubUrl: "https://github.com/ValkyrLabs/graymatter-mcp",
+  name: "GrayMatter MCP",
+  author: "ValkyrLabs",
+  description: "First-party MCP",
+  icon: "",
+  logoUrl: "",
+  category: "memory",
+  tags: ["graymatter"],
+  requiresApiKey: false,
+  isRecommended: true,
+  githubStars: 42,
+  downloadCount: 7,
+  createdAt: "2026-05-24T00:00:00.000Z",
+  updatedAt: "2026-05-24T00:00:00.000Z",
+  lastGithubSync: "2026-05-24T00:00:00.000Z",
+};
+
+describe("McpMarketplaceCard", () => {
+  beforeEach(() => {
+    mockPostMessage.mockReset();
+  });
+
+  it("routes internal app cards to hosted application detail with attribution", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <McpMarketplaceCard
+        item={{ ...baseItem, applicationId: "app-123" } as any}
+        installedServers={[]}
+      />,
+    );
+
+    await user.click(container.querySelector(".mcp-card") as HTMLAnchorElement);
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "openInBrowser",
+        url: expect.stringContaining("https://valkyrlabs.com/application-detail/app-123?"),
+      }),
+    );
+
+    const payload = mockPostMessage.mock.calls[0][0] as { url: string };
+    const url = new URL(payload.url);
+    expect(url.searchParams.get("source")).toBe("valoride");
+    expect(url.searchParams.get("surface")).toBe("mcp_marketplace");
+    expect(url.searchParams.get("mcpId")).toBe("mcp-graymatter");
+    expect(url.searchParams.get("applicationId")).toBe("app-123");
+    expect(payload.url).not.toContain("localhost:5173");
+  });
+
+  it("keeps external/community cards on github links", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <McpMarketplaceCard item={baseItem as any} installedServers={[]} />,
+    );
+
+    await user.click(container.querySelector(".mcp-card") as HTMLAnchorElement);
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "openInBrowser",
+        url: "https://github.com/ValkyrLabs/graymatter-mcp",
+      }),
+    );
+  });
+});

--- a/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceCard.tsx
+++ b/webview-ui/src/components/mcp/configuration/tabs/marketplace/McpMarketplaceCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useRef, useMemo } from "react";
+import { useCallback, useState, useRef, useMemo, type MouseEvent } from "react";
 import styled from "styled-components";
 import { McpMarketplaceItem, McpServer } from "@shared/mcp";
 import { vscode } from "@thorapi/utils/vscode";
@@ -115,6 +115,17 @@ const McpMarketplaceCard = ({
     return !!(item as any).applicationId;
   }, [item]);
 
+  const openDetail = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      vscode.postMessage({
+        type: "openInBrowser",
+        url: detailUrl,
+      });
+    },
+    [detailUrl],
+  );
+
   return (
     <>
       <style>
@@ -134,13 +145,7 @@ const McpMarketplaceCard = ({
       <a
         href={detailUrl}
         className="mcp-card"
-        onClick={(e) => {
-          e.preventDefault();
-          vscode.postMessage({
-            type: "openInBrowser",
-            url: detailUrl,
-          });
-        }}
+        onClick={openDetail}
         style={{
           padding: "14px 16px",
           display: "flex",


### PR DESCRIPTION
## Summary
- Apply the still-relevant #3106 marketplace-card behavior to `rc-5`
- Keep hosted application detail URLs behind `openInBrowser` webview messaging
- Add focused coverage for internal app cards and external/community GitHub cards

## Notes
- Existing PRs #93-#96 were probed against `rc-5`; their changes are already present or superseded on rc-5.
- PR #59 has no unique commits versus `rc-5`.
- PR #56 had one unique relevant commit, carried here.

## Verification
- Attempted: `npm --prefix webview-ui exec -- vitest run src/components/mcp/configuration/tabs/marketplace/McpMarketplaceCard.test.tsx`
- Blocked by existing rc-5 `vite.config.ts` syntax error: `Unexpected "}"` at line 72.
