### PR TITLE
fix(packaging): require runtime bundles in VSIX audit

### DIFF
--- a/scripts/audit-vsix-package.mjs
+++ b/scripts/audit-vsix-package.mjs
@@ -30,6 +30,12 @@ const ALLOWED_RUNTIME_ENTRY_PATTERNS = [
   /^extension\/assets\/valorIde\.acorn$/,
 ];
 
+const REQUIRED_RUNTIME_ENTRIES = [
+  { id: 'manifest', test: (entry) => entry.name === 'extension/package.json', message: 'extension/package.json is required' },
+  { id: 'extension_bundle', test: (entry) => entry.name === 'extension/dist/extension.js', message: 'extension/dist/extension.js is required' },
+  { id: 'webview_bundle', test: (entry) => entry.name.startsWith('extension/dist/webview/'), message: 'dist/webview assets are required' },
+];
+
 export function parseUnzipListing(listing) {
   const entries = [];
   for (const line of listing.split(/\r?\n/)) {
@@ -50,6 +56,7 @@ export function auditEntries(entries, options = {}) {
   const totalUncompressedBytes = entries.reduce((sum, entry) => sum + entry.size, 0);
   const forbiddenMatches = [];
   const unexpectedRuntimeEntries = [];
+  const missingRuntimeEntries = [];
 
   for (const entry of entries) {
     for (const rule of FORBIDDEN_RULES) {
@@ -59,6 +66,12 @@ export function auditEntries(entries, options = {}) {
     }
     if (!ALLOWED_RUNTIME_ENTRY_PATTERNS.some((pattern) => pattern.test(entry.name))) {
       unexpectedRuntimeEntries.push({ path: entry.name, size: entry.size });
+    }
+  }
+
+  for (const requiredEntry of REQUIRED_RUNTIME_ENTRIES) {
+    if (!entries.some(requiredEntry.test)) {
+      missingRuntimeEntries.push({ rule: requiredEntry.id, message: requiredEntry.message });
     }
   }
 
@@ -75,6 +88,9 @@ export function auditEntries(entries, options = {}) {
   if (unexpectedRuntimeEntries.length > 0) {
     failures.push(`${unexpectedRuntimeEntries.length} entries outside the runtime package allowlist detected`);
   }
+  if (missingRuntimeEntries.length > 0) {
+    failures.push(`${missingRuntimeEntries.length} required runtime entries missing`);
+  }
 
   return {
     ok: failures.length === 0,
@@ -85,6 +101,7 @@ export function auditEntries(entries, options = {}) {
     failures,
     forbiddenMatches,
     unexpectedRuntimeEntries,
+    missingRuntimeEntries,
     largestFiles: [...entries].sort((a, b) => b.size - a.size).slice(0, 50),
   };
 }
@@ -111,6 +128,11 @@ export function formatMarkdownReport(report, vsixPath = 'unknown') {
     '## Unexpected runtime entries',
     ...(report.unexpectedRuntimeEntries.length
       ? report.unexpectedRuntimeEntries.slice(0, 100).map((entry) => `- ${entry.path} (${entry.size} bytes)`)
+      : ['- none']),
+    '',
+    '## Missing runtime entries',
+    ...(report.missingRuntimeEntries.length
+      ? report.missingRuntimeEntries.map((entry) => `- ${entry.rule}: ${entry.message}`)
       : ['- none']),
     '',
     '## Largest files',

--- a/scripts/audit-vsix-package.test.mjs
+++ b/scripts/audit-vsix-package.test.mjs
@@ -90,14 +90,31 @@ test('auditEntries enforces the runtime package allowlist', () => {
   ]);
 });
 
+test('auditEntries fails packages missing required runtime bundles', () => {
+  const report = auditEntries([
+    { size: 10, name: '[Content_Types].xml' },
+    { size: 10, name: 'extension.vsixmanifest' },
+    { size: 20, name: 'extension/package.json' },
+    { size: 20, name: 'extension/README.md' },
+  ], { archiveBytes: 60, maxArchiveBytes: 1000, maxFileCount: 20 });
+
+  assert.equal(report.ok, false);
+  assert.match(report.failures.join('\n'), /required runtime entries missing/);
+  assert.deepEqual(report.missingRuntimeEntries.map((entry) => entry.rule), [
+    'extension_bundle',
+    'webview_bundle',
+  ]);
+});
+
 test('formatMarkdownReport includes package summary and largest files', () => {
   const report = auditEntries([
     { size: 20, name: 'extension/dist/extension.js' },
     { size: 10, name: 'extension/package.json' },
+    { size: 10, name: 'extension/dist/webview/assets/index.js' },
   ], { archiveBytes: 30, maxArchiveBytes: 1000, maxFileCount: 10 });
 
   const markdown = formatMarkdownReport(report, 'valoride.vsix');
   assert.match(markdown, /Status: PASS/);
-  assert.match(markdown, /File count: 2/);
+  assert.match(markdown, /File count: 3/);
   assert.match(markdown, /20\textension\/dist\/extension.js/);
 });


### PR DESCRIPTION
## What Problem This Solves
Prevents a malformed but small ValorIDE VSIX from passing the package audit when required runtime bundles are missing. This supports ValkyrLabs/ValkyrAI#2949.

## Why This Change Was Made
The existing audit blocked bloat sources and unexpected files, but an over-pruned package could still pass if it stayed under size/file budgets and only contained allowlisted metadata.

## User Impact
Release packaging now protects both sides of the trust signal: the VSIX must stay small and must still include the extension bundle plus webview assets needed to boot.

## Evidence
- npm run test:package-audit

Fixes ValkyrLabs/ValkyrAI#2949