### PR TITLE
feat(graymatter): add durable memory replay queue

### DIFF
--- a/src/services/graymatter/GrayMatterReplayQueue.test.ts
+++ b/src/services/graymatter/GrayMatterReplayQueue.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  DurableStateStore,
+  GrayMatterReplayQueue,
+} from "./GrayMatterReplayQueue";
+
+class MemoryStateStore implements DurableStateStore {
+  public data = new Map<string, unknown>();
+
+  get<T>(key: string, defaultValue: T): T {
+    return (this.data.has(key) ? this.data.get(key) : defaultValue) as T;
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    this.data.set(key, value);
+  }
+}
+
+describe("GrayMatterReplayQueue", () => {
+  let store: MemoryStateStore;
+  let now: number;
+  let queue: GrayMatterReplayQueue;
+
+  beforeEach(() => {
+    store = new MemoryStateStore();
+    now = 1_783_000_000_000;
+    queue = new GrayMatterReplayQueue(
+      store,
+      "test.graymatter.queue",
+      () => now,
+    );
+  });
+
+  it("persists queued writes in durable extension state", async () => {
+    const queued = await queue.enqueue({
+      operation: "memory.put",
+      payload: { text: "remember the activation decision" },
+      provenance: { workspace: "demo", taskId: "task-1" },
+    });
+
+    const restored = new GrayMatterReplayQueue(
+      store,
+      "test.graymatter.queue",
+      () => now,
+    );
+
+    expect(restored.list()).toEqual([queued]);
+    expect(restored.summary()).toEqual({
+      total: 1,
+      queued: 1,
+      replaying: 0,
+      blocked: 0,
+      failed: 0,
+    });
+  });
+
+  it("redacts secrets before writes are stored", async () => {
+    const queued = await queue.enqueue({
+      operation: "memory.put",
+      payload: {
+        text: "queue this",
+        nested: {
+          apiKey: "sk-live-should-not-survive",
+          authorization: "Bearer bad-news",
+        },
+      },
+      provenance: {
+        refreshToken: "refresh-me-not",
+        workspace: "demo",
+      },
+    });
+
+    expect(queued.payload).toEqual({
+      text: "queue this",
+      nested: {
+        apiKey: "[redacted]",
+        authorization: "[redacted]",
+      },
+    });
+    expect(queued.provenance).toEqual({
+      refreshToken: "[redacted]",
+      workspace: "demo",
+    });
+  });
+
+  it("deduplicates queued writes by caller-provided idempotency key", async () => {
+    const write = {
+      operation: "memory.put" as const,
+      payload: { text: "only once" },
+      provenance: { idempotencyKey: "workspace-task-message-1" },
+    };
+
+    const first = await queue.enqueue(write);
+    const second = await queue.enqueue(write);
+
+    expect(second).toEqual(first);
+    expect(queue.list()).toHaveLength(1);
+  });
+
+  it("classifies retryable and blocking replay failures separately", async () => {
+    const queued = await queue.enqueue({
+      operation: "memory.put",
+      payload: { text: "classify me" },
+    });
+
+    now += 1_000;
+    const replaying = await queue.markReplaying(queued.id);
+    expect(replaying?.status).toBe("replaying");
+    expect(replaying?.attemptCount).toBe(1);
+
+    now += 1_000;
+    const retryable = await queue.markFailed(
+      queued.id,
+      "unavailable",
+      "api-0 unavailable",
+      now + 30_000,
+    );
+    expect(retryable?.status).toBe("failed");
+    expect(retryable?.nextAttemptAt).toBe(now + 30_000);
+
+    now += 1_000;
+    const blocked = await queue.markFailed(
+      queued.id,
+      "credits",
+      "credit recovery required",
+    );
+    expect(blocked?.status).toBe("blocked");
+    expect(blocked?.failureKind).toBe("credits");
+  });
+
+  it("removes completed or discarded writes", async () => {
+    const queued = await queue.enqueue({
+      operation: "memory.put",
+      payload: { text: "done" },
+    });
+
+    await expect(queue.complete(queued.id)).resolves.toBe(true);
+    expect(queue.list()).toEqual([]);
+    await expect(queue.discard("missing")).resolves.toBe(false);
+  });
+});

--- a/src/services/graymatter/GrayMatterReplayQueue.ts
+++ b/src/services/graymatter/GrayMatterReplayQueue.ts
@@ -1,0 +1,236 @@
+export type GrayMatterReplayFailureKind =
+  | "unavailable"
+  | "auth"
+  | "credits"
+  | "forbidden"
+  | "validation"
+  | "unknown";
+
+export type GrayMatterReplayStatus =
+  | "queued"
+  | "replaying"
+  | "blocked"
+  | "failed";
+
+export interface GrayMatterReplayWrite {
+  operation: "memory.put" | "memory.put_batch" | "memory.link";
+  payload: Record<string, unknown>;
+  provenance?: Record<string, unknown>;
+}
+
+export interface GrayMatterReplayItem extends GrayMatterReplayWrite {
+  id: string;
+  idempotencyKey: string;
+  status: GrayMatterReplayStatus;
+  createdAt: number;
+  updatedAt: number;
+  attemptCount: number;
+  nextAttemptAt?: number;
+  failureKind?: GrayMatterReplayFailureKind;
+  lastError?: string;
+}
+
+export interface GrayMatterReplayQueueSummary {
+  total: number;
+  queued: number;
+  replaying: number;
+  blocked: number;
+  failed: number;
+}
+
+export interface DurableStateStore {
+  get<T>(key: string, defaultValue: T): T;
+  update(key: string, value: unknown): PromiseLike<void>;
+}
+
+const DEFAULT_STORAGE_KEY = "graymatter.replayQueue.v1";
+const SENSITIVE_KEY_PATTERN =
+  /(^|[-_])(authorization|api[-_]?key|jwt|password|refresh[-_]?token|secret|token)($|[-_])/i;
+const REDACTED = "[redacted]";
+
+export class GrayMatterReplayQueue {
+  constructor(
+    private readonly storage: DurableStateStore,
+    private readonly storageKey: string = DEFAULT_STORAGE_KEY,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  async enqueue(write: GrayMatterReplayWrite): Promise<GrayMatterReplayItem> {
+    const timestamp = this.now();
+    const sanitizedWrite = sanitizeWrite(write);
+    const idempotencyKey =
+      typeof sanitizedWrite.provenance?.idempotencyKey === "string"
+        ? sanitizedWrite.provenance.idempotencyKey
+        : buildIdempotencyKey(sanitizedWrite);
+    const existing = this.list().find(
+      (item) => item.idempotencyKey === idempotencyKey,
+    );
+
+    if (existing) {
+      return existing;
+    }
+
+    const item: GrayMatterReplayItem = {
+      ...sanitizedWrite,
+      id: `gmq_${timestamp}_${stableHash(idempotencyKey)}`,
+      idempotencyKey,
+      status: "queued",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      attemptCount: 0,
+    };
+
+    await this.save([...this.list(), item]);
+    return item;
+  }
+
+  list(): GrayMatterReplayItem[] {
+    const items = this.storage.get<GrayMatterReplayItem[]>(this.storageKey, []);
+    return Array.isArray(items) ? items : [];
+  }
+
+  async markReplaying(id: string): Promise<GrayMatterReplayItem | null> {
+    return this.updateItem(id, (item) => ({
+      ...item,
+      status: "replaying",
+      updatedAt: this.now(),
+      attemptCount: item.attemptCount + 1,
+      failureKind: undefined,
+      lastError: undefined,
+    }));
+  }
+
+  async markFailed(
+    id: string,
+    failureKind: GrayMatterReplayFailureKind,
+    error: string,
+    nextAttemptAt?: number,
+  ): Promise<GrayMatterReplayItem | null> {
+    return this.updateItem(id, (item) => ({
+      ...item,
+      status: isBlockingFailure(failureKind) ? "blocked" : "failed",
+      updatedAt: this.now(),
+      failureKind,
+      lastError: error,
+      nextAttemptAt,
+    }));
+  }
+
+  async complete(id: string): Promise<boolean> {
+    const before = this.list();
+    const after = before.filter((item) => item.id !== id);
+
+    if (after.length === before.length) {
+      return false;
+    }
+
+    await this.save(after);
+    return true;
+  }
+
+  async discard(id: string): Promise<boolean> {
+    return this.complete(id);
+  }
+
+  summary(): GrayMatterReplayQueueSummary {
+    return this.list().reduce<GrayMatterReplayQueueSummary>(
+      (summary, item) => {
+        summary.total += 1;
+        summary[item.status] += 1;
+        return summary;
+      },
+      { total: 0, queued: 0, replaying: 0, blocked: 0, failed: 0 },
+    );
+  }
+
+  private async updateItem(
+    id: string,
+    updater: (item: GrayMatterReplayItem) => GrayMatterReplayItem,
+  ): Promise<GrayMatterReplayItem | null> {
+    let updated: GrayMatterReplayItem | null = null;
+    const items = this.list().map((item) => {
+      if (item.id !== id) {
+        return item;
+      }
+
+      updated = updater(item);
+      return updated;
+    });
+
+    if (!updated) {
+      return null;
+    }
+
+    await this.save(items);
+    return updated;
+  }
+
+  private async save(items: GrayMatterReplayItem[]): Promise<void> {
+    await this.storage.update(this.storageKey, items);
+  }
+}
+
+function sanitizeWrite(write: GrayMatterReplayWrite): GrayMatterReplayWrite {
+  return {
+    operation: write.operation,
+    payload: redactSensitiveValues(write.payload),
+    provenance: write.provenance
+      ? redactSensitiveValues(write.provenance)
+      : undefined,
+  };
+}
+
+function redactSensitiveValues(value: unknown): any {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitiveValues(item));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).reduce<
+      Record<string, unknown>
+    >((safe, [key, nestedValue]) => {
+      safe[key] = SENSITIVE_KEY_PATTERN.test(key)
+        ? REDACTED
+        : redactSensitiveValues(nestedValue);
+      return safe;
+    }, {});
+  }
+
+  return value;
+}
+
+function buildIdempotencyKey(write: GrayMatterReplayWrite): string {
+  return `valoride:${write.operation}:${stableHash(stableStringify(write))}`;
+}
+
+function isBlockingFailure(failureKind: GrayMatterReplayFailureKind): boolean {
+  return ["auth", "credits", "forbidden", "validation"].includes(failureKind);
+}
+
+function stableHash(value: string): string {
+  let hash = 5381;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 33) ^ value.charCodeAt(index);
+  }
+
+  return (hash >>> 0).toString(36);
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(
+        ([key, nestedValue]) =>
+          `${JSON.stringify(key)}:${stableStringify(nestedValue)}`,
+      )
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+}


### PR DESCRIPTION
## Summary
- add a durable GrayMatter replay queue backed by VS Code-compatible global state
- redact sensitive payload/provenance fields before persistence
- track queued/replaying/failed/blocked states with idempotency keys and summary counts

## Tests
- npx --yes prettier@3.3.3 --write src/services/graymatter/GrayMatterReplayQueue.ts src/services/graymatter/GrayMatterReplayQueue.test.ts
- tsc --noEmit --target es2022 --module esnext --moduleResolution bundler src/services/graymatter/GrayMatterReplayQueue.ts
- npx --yes vitest@3.1.2 run src/services/graymatter/GrayMatterReplayQueue.test.ts --config /dev/null

## Notes
- `yarn install --frozen-lockfile` is currently blocked by existing lockfile drift before dependencies install.

Closes ValkyrLabs/ValkyrAI#2978