### PR TITLE
feat(graymatter): retry blocked quota actions

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -2579,6 +2579,20 @@ export class Controller {
         });
         break;
       }
+      case "retryGrayMatterBlockedAction": {
+        const session = await this.refreshGrayMatterSessionState();
+        await this.postStateToWebview();
+        if (session.status === "ready") {
+          void vscode.window.showInformationMessage(
+            `GrayMatter credits are ready. Retry ${message.resumeActionLabel ?? message.resumeCapabilityId ?? "the blocked action"}.`,
+          );
+        } else {
+          void vscode.window.showWarningMessage(
+            `GrayMatter is still ${session.status}. Recharge or sign in before retrying the blocked action.`,
+          );
+        }
+        break;
+      }
       case "showMcpView": {
         await this.postMessageToWebview({
           type: "action",

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -63,6 +63,7 @@ export interface WebviewMessage {
     | "accountLoginClicked"
     | "accountLogoutClicked"
     | "showAccountViewClicked"
+    | "retryGrayMatterBlockedAction"
     | "authStateChanged"
     | "authCallback"
     | "fetchMcpMarketplace"
@@ -169,6 +170,9 @@ export interface WebviewMessage {
   password?: string;
   // For openInBrowser
   url?: string;
+  resumeCommandId?: string;
+  resumeCapabilityId?: string;
+  resumeActionLabel?: string;
   planActSeparateModelsSetting?: boolean;
   telemetrySetting?: TelemetrySetting;
   customInstructionsSetting?: string;

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.test.tsx
@@ -224,6 +224,25 @@ describe("CapabilityCommandCenter", () => {
     expect(mockPostMessage).toHaveBeenLastCalledWith({
       type: "showAccountViewClicked",
     });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Retry after recharge" }),
+    );
+    expect(mockPostMessage).toHaveBeenLastCalledWith({
+      resumeActionLabel: "Recall project memory",
+      resumeCapabilityId: "graymatter.memory",
+      resumeCommandId: "cmd-quota-1",
+      type: "retryGrayMatterBlockedAction",
+    });
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      event: "valoride_activation_recovery_action",
+      payload: {
+        action: "retry_after_recharge",
+        status: "quota",
+        surface: "graymatter",
+      },
+      type: "trackFunnelEvent",
+    });
   });
 
   it("opens the local ValorIDE sign-in panel for unauthenticated sessions", async () => {

--- a/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
+++ b/webview-ui/src/components/agentic/CapabilityCommandCenter.tsx
@@ -290,6 +290,19 @@ const GrayMatterQuotaRecovery = ({
       url: quotaRecoveryUrl(path, state, grayMatterSession, latestCommand),
     });
   };
+  const retryBlockedAction = () => {
+    trackRecoveryAction(
+      grayMatterSession?.status,
+      "retry_after_recharge",
+      "graymatter",
+    );
+    vscode.postMessage({
+      type: "retryGrayMatterBlockedAction",
+      resumeCommandId: context.commandId,
+      resumeCapabilityId: context.capabilityId,
+      resumeActionLabel: context.label,
+    });
+  };
 
   return (
     <div className="capability-command-center__quota" role="alert">
@@ -327,6 +340,11 @@ const GrayMatterQuotaRecovery = ({
         >
           View usage
         </button>
+        {context.commandId ? (
+          <button type="button" onClick={retryBlockedAction}>
+            Retry after recharge
+          </button>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a retry-after-recharge CTA to the GrayMatter quota recovery panel
- preserve blocked command/capability/action context in the webview message contract
- refresh GrayMatter credit/session state from the extension controller before prompting the user to retry

## Tests
- git diff --check
- npm test -- CapabilityCommandCenter.test.tsx --runInBand (blocked: npm ci failed with ENOSPC while installing webview-ui dependencies)

Refs ValkyrLabs/ValkyrAI#2957