### PR TITLE
feat(marketplace): rank services by real popularity signals

### DIFF
--- a/src/services/monetization/ServiceMonetizationService.ts
+++ b/src/services/monetization/ServiceMonetizationService.ts
@@ -20,6 +20,10 @@ export interface ManagedMcpService {
   isMonetized: boolean;
   createdAt: string;
   updatedAt: string;
+  subscriptionCount?: number;
+  invocationCount?: number;
+  rating?: number;
+  verifiedPublisher?: boolean;
 }
 
 export interface CreatorEarnings {

--- a/src/views/MonetizedServicesMarketplace.tsx
+++ b/src/views/MonetizedServicesMarketplace.tsx
@@ -8,6 +8,7 @@ import {
   buildTrustSignals,
   getEstimatedSpendLabel,
   getCreatorDisplayName,
+  getMarketplacePopularityScore,
   getServicePricingSummary,
 } from "./monetizedServicesMarketplaceUtils";
 import "./MonetizedServicesMarketplace.css";
@@ -86,7 +87,9 @@ export const MonetizedServicesMarketplace: React.FC = () => {
       case "price-low":
         return (a.costPerCall || 999) - (b.costPerCall || 999);
       case "popular":
-        return b.updatedAt.localeCompare(a.updatedAt);
+        return (
+          getMarketplacePopularityScore(b) - getMarketplacePopularityScore(a)
+        );
       default:
         return b.createdAt.localeCompare(a.createdAt);
     }

--- a/src/views/monetizedServicesMarketplaceUtils.test.ts
+++ b/src/views/monetizedServicesMarketplaceUtils.test.ts
@@ -4,6 +4,7 @@ import {
   estimateMonthlyCreditSpend,
   getCreatorDisplayName,
   getEstimatedSpendLabel,
+  getMarketplacePopularityScore,
   getServicePricingSummary,
 } from "./monetizedServicesMarketplaceUtils";
 import { ManagedMcpService } from "@thorapi/services/monetization/ServiceMonetizationService";
@@ -62,5 +63,26 @@ describe("monetized service marketplace helpers", () => {
       "ValkyrAI billing ledger",
       "Creator support required",
     ]);
+  });
+
+  it("ranks popularity from real marketplace signals instead of recency alone", () => {
+    const olderPopularService = service({
+      updatedAt: "2026-05-01T00:00:00Z",
+      subscriptionCount: 12,
+      invocationCount: 900,
+      rating: 4.8,
+      verifiedPublisher: true,
+    });
+    const newerQuietService = service({
+      updatedAt: new Date().toISOString(),
+      subscriptionCount: 0,
+      invocationCount: 1,
+      rating: 5,
+      verifiedPublisher: false,
+    });
+
+    expect(getMarketplacePopularityScore(olderPopularService)).toBeGreaterThan(
+      getMarketplacePopularityScore(newerQuietService),
+    );
   });
 });

--- a/src/views/monetizedServicesMarketplaceUtils.ts
+++ b/src/views/monetizedServicesMarketplaceUtils.ts
@@ -44,6 +44,24 @@ export function getEstimatedSpendLabel(
   return spend === null ? "Plan based" : `${spend} credits`;
 }
 
+export function getMarketplacePopularityScore(
+  service: ManagedMcpService,
+): number {
+  const subscriptions = Math.max(0, service.subscriptionCount ?? 0);
+  const invocations = Math.max(0, service.invocationCount ?? 0);
+  const rating = Math.max(0, Math.min(5, service.rating ?? 0));
+  const verifiedBoost = service.verifiedPublisher ? 50 : 0;
+  const recencyBoost = getRecencyBoost(service.updatedAt || service.createdAt);
+
+  return (
+    subscriptions * 100 +
+    invocations * 0.1 +
+    rating * 20 +
+    verifiedBoost +
+    recencyBoost
+  );
+}
+
 export function buildTrustSignals(service: ManagedMcpService): string[] {
   const signals = [
     service.status === "MONETIZED" ? "Monetized service" : "Published service",
@@ -53,4 +71,18 @@ export function buildTrustSignals(service: ManagedMcpService): string[] {
   ];
 
   return signals;
+}
+
+function getRecencyBoost(timestamp: string | undefined): number {
+  if (!timestamp) {
+    return 0;
+  }
+
+  const ageMs = Date.now() - new Date(timestamp).getTime();
+  if (!Number.isFinite(ageMs) || ageMs < 0) {
+    return 0;
+  }
+
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+  return Math.max(0, 14 - Math.floor(ageDays));
 }


### PR DESCRIPTION
## Summary
- add marketplace popularity signal fields to managed MCP service typing
- rank Most Popular by subscription count, invocation count, rating, verified publisher status, and light recency boost instead of updatedAt alone
- cover ranking behavior with a focused Vitest unit test

Linked ValkyrAI Ready issue: ValkyrLabs/ValkyrAI#2890

## Verification
- yarn vitest run src/views/monetizedServicesMarketplaceUtils.test.ts
- yarn prettier src/services/monetization/ServiceMonetizationService.ts src/views/monetizedServicesMarketplaceUtils.ts src/views/MonetizedServicesMarketplace.tsx src/views/monetizedServicesMarketplaceUtils.test.ts --check

## Known repo-wide check
- yarn check-types currently fails on unrelated existing issues in startupRevealPolicy.test.ts, useDiscoveryQuery.ts, missing @testing-library/user-event, BuyCredits tests, and missing three typings.