### PR TITLE
fix(marketplace): rank services by traction signals

### DIFF
--- a/src/views/MonetizedServicesMarketplace.helpers.test.ts
+++ b/src/views/MonetizedServicesMarketplace.helpers.test.ts
@@ -52,20 +52,26 @@ describe("MonetizedServicesMarketplace helpers", () => {
     expect(estimateMonthlySpend(monthly)).toBe("$49/month before overages");
   });
 
-  it("sorts trust-ready services ahead of non-monetized services for popular view", () => {
-    const draft = service({
-      id: "draft",
-      isMonetized: false,
+  it("sorts services by real marketplace traction instead of updated recency", () => {
+    const freshButQuiet = service({
+      id: "fresh-quiet",
       updatedAt: "2026-05-05T00:00:00.000Z",
+      subscriberCount: 1,
+      invocationCount: 10,
+      averageRating: 3,
     });
-    const monetized = service({
-      id: "monetized",
-      isMonetized: true,
+    const provenService = service({
+      id: "proven",
       updatedAt: "2026-05-01T00:00:00.000Z",
+      subscriberCount: 25,
+      invocationCount: 300,
+      averageRating: 4.8,
     });
 
-    expect(sortMarketplaceServices([draft, monetized], "popular")[0].id).toBe(
-      "monetized",
+    expect(
+      sortMarketplaceServices([freshButQuiet, provenService], "popular")[0].id,
+    ).toBe(
+      "proven",
     );
   });
 });

--- a/src/views/MonetizedServicesMarketplace.helpers.ts
+++ b/src/views/MonetizedServicesMarketplace.helpers.ts
@@ -1,4 +1,5 @@
 import { ManagedMcpService } from "@thorapi/services/monetization/ServiceMonetizationService";
+import { getServicePopularityScore } from "./monetizedMarketplaceFunnel";
 
 export type MarketplaceSort = "newest" | "popular" | "price-low";
 export type PurchaseSheetMode = "details" | "subscribe";
@@ -52,7 +53,7 @@ export function sortMarketplaceServices(
         );
       case "popular":
         return (
-          Number(b.isMonetized) - Number(a.isMonetized) ||
+          getServicePopularityScore(b) - getServicePopularityScore(a) ||
           b.updatedAt.localeCompare(a.updatedAt)
         );
       default:


### PR DESCRIPTION
## Summary
- rank the marketplace popular view with the existing traction score instead of monetized/updatedAt proxy ordering
- update the helper regression test to prove subscriber, invocation, and rating signals outrank recency

## Verification
- PASS: npx vitest run src/views/MonetizedServicesMarketplace.helpers.test.ts
- BLOCKED: npm run compile (pre-existing unrelated TypeScript errors in src/services/llmPromptService.ts and webview-ui OpenAPI/three imports)

Related: ValkyrLabs/ValkyrAI#2890