### PR TITLE
fix(valoride): route credit purchases through checkout

### DIFF
--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -23,6 +23,7 @@
         "posthog-js": "1.282.0",
         "pretty-bytes": "6.1.1",
         "react": "18.3.1",
+        "react-bootstrap": "2.10.10",
         "react-countup": "6.5.3",
         "react-dom": "18.3.1",
         "react-icons": "5.5.0",
@@ -40,6 +41,7 @@
       "devDependencies": {
         "@eslint/js": "9.38.0",
         "@tailwindcss/vite": "4.1.16",
+        "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.0",
         "@testing-library/user-event": "14.6.1",
@@ -1244,6 +1246,33 @@
         "mlly": "^1.7.4"
       }
     },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.9.tgz",
+      "integrity": "sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1557,6 +1586,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@posthog/core": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.4.0.tgz",
@@ -1725,6 +1764,32 @@
         "react-dom": ">=18.0.0"
       }
     },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.10.1.tgz",
+      "integrity": "sha512-jn038/ZYmu6DpfXJ6r2U9zFFppjbc9wnApPJSCxao2RZVEqep4YyoniHSy8qv6V21/xyS4IV7W9a+X2jOjSuag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.0.tgz",
+      "integrity": "sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
@@ -1764,6 +1829,60 @@
       "license": "MIT",
       "peerDependencies": {
         "redux": "^5.0.0"
+      }
+    },
+    "node_modules/@restart/hooks": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@restart/ui": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
+      "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@popperjs/core": "^2.11.8",
+        "@react-aria/ssr": "^3.5.0",
+        "@restart/hooks": "^0.5.0",
+        "@types/warning": "^3.0.3",
+        "dequal": "^2.0.3",
+        "dom-helpers": "^5.2.0",
+        "uncontrollable": "^8.0.4",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/@restart/hooks": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
+      "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/uncontrollable": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
+      "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.14.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2322,6 +2441,15 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@swc/types": {
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
@@ -2664,6 +2792,78 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2725,6 +2925,13 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3110,14 +3317,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.26",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3132,6 +3337,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -3178,6 +3392,12 @@
       "resolved": "https://registry.npmjs.org/@types/vscode-webview/-/vscode-webview-1.57.5.tgz",
       "integrity": "sha512-iBAUYNYkz+uk1kdsq05fEcoh8gJmwT3lqqFPN7MGyjQ3HVloViMdo7ZJ8DFIP8WOK74PjOEilosqAyxV2iUFUw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/warning": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.4.tgz",
+      "integrity": "sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -3805,6 +4025,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -4875,6 +5107,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
@@ -5758,6 +6000,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-alphabetical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
@@ -6621,6 +6872,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6956,6 +7217,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7275,6 +7545,42 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types-extra": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
+      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^16.3.2",
+        "warning": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
+      }
+    },
+    "node_modules/prop-types-extra/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "5.6.0",
@@ -7954,6 +8260,58 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-aria": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.50.0.tgz",
+      "integrity": "sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.48.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-bootstrap": {
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.10.tgz",
+      "integrity": "sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7",
+        "@restart/hooks": "^0.4.9",
+        "@restart/ui": "^1.9.4",
+        "@types/prop-types": "^15.7.12",
+        "@types/react-transition-group": "^4.4.6",
+        "classnames": "^2.3.2",
+        "dom-helpers": "^5.2.1",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.8.1",
+        "prop-types-extra": "^1.1.0",
+        "react-transition-group": "^4.4.5",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.8",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-countup": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/react-countup/-/react-countup-6.5.3.tgz",
@@ -7992,6 +8350,12 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -8077,6 +8441,23 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-stately": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.48.0.tgz",
+      "integrity": "sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/react-textarea-autosize": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
@@ -8092,6 +8473,22 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/react-universal-interface": {
@@ -9208,6 +9605,21 @@
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "license": "MIT"
     },
+    "node_modules/uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -9895,6 +10307,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/web-namespaces": {

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -31,6 +31,7 @@
     "posthog-js": "1.282.0",
     "pretty-bytes": "6.1.1",
     "react": "18.3.1",
+    "react-bootstrap": "2.10.10",
     "react-countup": "6.5.3",
     "react-dom": "18.3.1",
     "react-icons": "5.5.0",
@@ -48,6 +49,7 @@
   "devDependencies": {
     "@eslint/js": "9.38.0",
     "@tailwindcss/vite": "4.1.16",
+    "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.0",
     "@testing-library/user-event": "14.6.1",

--- a/webview-ui/src/components/BuyCredits/index.test.tsx
+++ b/webview-ui/src/components/BuyCredits/index.test.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import BuyCredits from ".";
+
+const mockCreateCartOrder = vi.fn();
+const mockCreateCheckoutSession = vi.fn();
+const mockRefreshBalance = vi.fn();
+const mockRecordPaymentTransaction = vi.fn();
+
+vi.mock("@valkyr/component-library/CoolButton", () => ({
+  __esModule: true,
+  default: ({ children, customStyle, ...props }: any) => (
+    <button style={customStyle} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("react-bootstrap", () => {
+  const Card = Object.assign(
+    ({ children, ...props }: any) => <section {...props}>{children}</section>,
+    {
+      Header: ({ children }: any) => <header>{children}</header>,
+      Body: ({ children }: any) => <div>{children}</div>,
+    },
+  );
+  const Form = Object.assign(
+    ({ children, ...props }: any) => <form {...props}>{children}</form>,
+    {
+      Group: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+      Label: ({ children, ...props }: any) => <label {...props}>{children}</label>,
+      Control: (props: any) => <input {...props} />,
+      Text: ({ children, ...props }: any) => <small {...props}>{children}</small>,
+    },
+  );
+  const InputGroup = Object.assign(
+    ({ children }: any) => <div>{children}</div>,
+    {
+      Text: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+    },
+  );
+
+  return {
+    __esModule: true,
+    Alert: ({ children }: any) => <div role="alert">{children}</div>,
+    Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    Card,
+    Form,
+    InputGroup,
+  };
+});
+
+vi.mock("../../redux/customBaseQuery", () => ({
+  __esModule: true,
+  default: vi.fn(),
+}));
+
+vi.mock("../../services/creditsApi", async () => {
+  const actual = await vi.importActual<any>("../../services/creditsApi");
+  return {
+    ...actual,
+    useCreateCartOrderMutation: () => [mockCreateCartOrder],
+    useCreateCheckoutSessionMutation: () => [mockCreateCheckoutSession],
+    useLazyGetAccountBalanceQuery: () => [mockRefreshBalance],
+    useRecordPaymentTransactionMutation: () => [mockRecordPaymentTransaction],
+  };
+});
+
+describe("BuyCredits", () => {
+  beforeEach(() => {
+    mockCreateCartOrder.mockReset();
+    mockCreateCheckoutSession.mockReset();
+    mockRefreshBalance.mockReset();
+    mockRecordPaymentTransaction.mockReset();
+    vi.spyOn(globalThis, "open").mockImplementation(() => null);
+  });
+
+  it("starts server-owned Stripe checkout instead of direct ledger booking", async () => {
+    mockCreateCartOrder.mockReturnValue({
+      unwrap: () => Promise.resolve({ orderId: "order-123" }),
+    });
+    mockCreateCheckoutSession.mockReturnValue({
+      unwrap: () =>
+        Promise.resolve({
+          checkout_url: "https://checkout.stripe.com/session-123",
+        }),
+    });
+
+    render(
+      <BuyCredits
+        authenticatedPrincipal={{ id: "principal-123", username: "casey" }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Buy \$10 Credits/i }));
+
+    await waitFor(() => {
+      expect(mockCreateCartOrder).toHaveBeenCalledWith({
+        lineItems: [
+          {
+            sku: "prod_ThB4xwTOkam2P3",
+            quantity: 2,
+            type: "product",
+          },
+        ],
+      });
+      expect(mockCreateCheckoutSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderId: "order-123",
+          currency: "usd",
+          mode: "payment",
+        }),
+      );
+      expect(globalThis.open).toHaveBeenCalledWith(
+        "https://checkout.stripe.com/session-123",
+        "_blank",
+        "noopener,noreferrer",
+      );
+    });
+
+    expect(mockRecordPaymentTransaction).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/Stripe checkout opened. Return here after payment/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/webview-ui/src/components/BuyCredits/index.tsx
+++ b/webview-ui/src/components/BuyCredits/index.tsx
@@ -2,7 +2,16 @@ import React, { useState } from "react";
 import { Card, Form, InputGroup, Button, Alert } from "react-bootstrap";
 import { FaCreditCard, FaShoppingCart, FaDollarSign } from "react-icons/fa";
 import CoolButton from "@valkyr/component-library/CoolButton";
-import { useRecordPaymentTransactionMutation } from "../../services/creditsApi";
+import {
+  buildValorIdeCheckoutUrls,
+  buildValorIdeCreditCartOrder,
+  getCheckoutUrl,
+  normalizeCreditCheckoutDollars,
+  VALORIDE_CREDIT_PACKAGE,
+  useCreateCartOrderMutation,
+  useCreateCheckoutSessionMutation,
+  useLazyGetAccountBalanceQuery,
+} from "../../services/creditsApi";
 
 interface BuyCreditsProps {
   authenticatedPrincipal?: any;
@@ -20,16 +29,21 @@ const BuyCredits: React.FC<BuyCreditsProps> = ({
   const [amount, setAmount] = useState<number>(10);
   const [isProcessing, setIsProcessing] = useState(false);
   const [message, setMessage] = useState<{
-    type: "success" | "error";
+    type: "success" | "error" | "info";
     text: string;
   } | null>(null);
+  const [pendingCheckoutAccountId, setPendingCheckoutAccountId] = useState<
+    string | null
+  >(null);
 
   // RTK Query mutations
-  const [recordPaymentTransaction] = useRecordPaymentTransactionMutation();
+  const [createCartOrder] = useCreateCartOrderMutation();
+  const [createCheckoutSession] = useCreateCheckoutSessionMutation();
+  const [refreshAccountBalance] = useLazyGetAccountBalanceQuery();
 
   const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value, 10);
-    if (!isNaN(value) && value >= 1) {
+    if (!isNaN(value) && value >= VALORIDE_CREDIT_PACKAGE.dollars) {
       setAmount(value);
     }
   };
@@ -81,42 +95,75 @@ const BuyCredits: React.FC<BuyCreditsProps> = ({
     setMessage(null);
 
     try {
-      // Record payment transaction - this is the primary operation
-      // The backend handles creating the account balance, transaction history, etc.
-      const paymentTx = {
-        paidAt: new Date().toISOString(),
-        amountCents: Math.round(amount * 100),
-        credits: amount,
-      };
+      const checkoutAmount = normalizeCreditCheckoutDollars(amount);
       const idempotencyKey =
         globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
+      const order = await createCartOrder(
+        buildValorIdeCreditCartOrder(checkoutAmount),
+      ).unwrap();
+      const orderId = order.orderId ?? order.id;
 
-      await recordPaymentTransaction({
-        accountId: accountId as string,
-        payment: paymentTx,
+      if (!orderId) {
+        throw new Error("Checkout order was not created.");
+      }
+
+      const checkoutSession = await createCheckoutSession({
+        orderId,
+        ...buildValorIdeCheckoutUrls(),
+        currency: "usd",
+        mode: "payment",
         idempotencyKey,
       }).unwrap();
+      const checkoutUrl = getCheckoutUrl(checkoutSession);
+
+      if (!checkoutUrl) {
+        throw new Error(
+          checkoutSession.error || "Stripe checkout URL was not returned.",
+        );
+      }
+
+      globalThis.open?.(checkoutUrl, "_blank", "noopener,noreferrer");
+      setPendingCheckoutAccountId(accountId as string);
 
       setMessage({
-        type: "success",
-        text: `Successfully added $${amount} credits! Your balance has been updated.`,
+        type: "info",
+        text: "Stripe checkout opened. Return here after payment and refresh your balance if credits are still reconciling.",
       });
-
-      // Call success callback
-      onPurchaseSuccess?.(amount);
-
-      // Reset form
-      setAmount(10);
-
-      // Auto-dismiss success message
-      setTimeout(() => {
-        setMessage(null);
-      }, 3000);
     } catch (error: any) {
       console.error("Purchase failed:", error);
       setMessage({
         type: "error",
-        text: error.data?.message || "Purchase failed. Please try again.",
+        text:
+          error.data?.message ||
+          error.data?.error ||
+          error.message ||
+          "Checkout could not be started. Please try again.",
+      });
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleRefreshBalance = async () => {
+    if (!pendingCheckoutAccountId) {
+      return;
+    }
+
+    setIsProcessing(true);
+    try {
+      await refreshAccountBalance(pendingCheckoutAccountId, false).unwrap();
+      setMessage({
+        type: "success",
+        text: "Balance refreshed. If credits are still pending, Stripe reconciliation may still be finishing.",
+      });
+      onPurchaseSuccess?.(amount);
+    } catch (error: any) {
+      setMessage({
+        type: "error",
+        text:
+          error.data?.message ||
+          error.data?.error ||
+          "Balance refresh failed. Please try again shortly.",
       });
     } finally {
       setIsProcessing(false);
@@ -127,7 +174,8 @@ const BuyCredits: React.FC<BuyCreditsProps> = ({
     return null;
   }
 
-  const disablePurchase = isProcessing || amount < 1;
+  const disablePurchase =
+    isProcessing || amount < VALORIDE_CREDIT_PACKAGE.dollars;
 
   return (
     <Card
@@ -147,7 +195,13 @@ const BuyCredits: React.FC<BuyCreditsProps> = ({
       <Card.Body>
         {message && (
           <Alert
-            variant={message.type === "success" ? "success" : "danger"}
+            variant={
+              message.type === "success"
+                ? "success"
+                : message.type === "info"
+                  ? "info"
+                  : "danger"
+            }
             className="mb-3"
             dismissible
             onClose={() => setMessage(null)}
@@ -177,8 +231,8 @@ const BuyCredits: React.FC<BuyCreditsProps> = ({
                 type="number"
                 value={amount}
                 onChange={handleAmountChange}
-                min="1"
-                step="1"
+                min={VALORIDE_CREDIT_PACKAGE.dollars}
+                step={VALORIDE_CREDIT_PACKAGE.dollars}
                 style={{
                   backgroundColor: "transparent",
                   borderColor: "#06ffa560",
@@ -187,7 +241,8 @@ const BuyCredits: React.FC<BuyCreditsProps> = ({
               />
             </InputGroup>
             <Form.Text className="text-muted">
-              Minimum $1, whole dollar amounts only
+              Minimum ${VALORIDE_CREDIT_PACKAGE.dollars}, server-priced credit
+              packages only
             </Form.Text>
           </Form.Group>
 
@@ -241,9 +296,23 @@ const BuyCredits: React.FC<BuyCreditsProps> = ({
             </CoolButton>
           </div>
 
+          {pendingCheckoutAccountId && (
+            <div className="d-grid gap-2 mt-2">
+              <Button
+                type="button"
+                variant="outline-success"
+                disabled={isProcessing}
+                onClick={handleRefreshBalance}
+              >
+                Refresh balance
+              </Button>
+            </div>
+          )}
+
           <div className="mt-2 text-center">
             <small className="text-muted">
-              Secure payment via Stripe • Instant credit delivery
+              Secure payment via Stripe • Credits post after webhook
+              reconciliation
             </small>
           </div>
         </Form>

--- a/webview-ui/src/services/creditsApi.test.ts
+++ b/webview-ui/src/services/creditsApi.test.ts
@@ -1,14 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../redux/customBaseQuery", () => ({
+  __esModule: true,
+  default: vi.fn(),
+}));
+
 import {
+  buildValorIdeCheckoutUrls,
+  buildValorIdeCreditCartOrder,
   chooseBestBalance,
   getAccountBalancePath,
   getAccountBalanceSummaryPath,
+  getCheckoutUrl,
   isInsufficientFunds,
   mergeAccountBalance,
   normalizeAccountBalance,
+  normalizeCreditCheckoutDollars,
   resolveBalanceLookupAccountIds,
   resolvePrimaryBalanceAccountId,
   selectSyncedAccountBalance,
+  VALORIDE_CREDIT_PACKAGE,
 } from "./creditsApi";
 
 describe("creditsApi isInsufficientFunds", () => {
@@ -209,5 +220,36 @@ describe("creditsApi balance request resolution", () => {
       "acct-456",
       "me",
     ]);
+  });
+});
+
+describe("ValorIDE credit checkout helpers", () => {
+  it("rounds credit purchases to server-priced package quantities", () => {
+    expect(normalizeCreditCheckoutDollars(1)).toBe(
+      VALORIDE_CREDIT_PACKAGE.dollars,
+    );
+    expect(normalizeCreditCheckoutDollars(12)).toBe(10);
+    expect(normalizeCreditCheckoutDollars(13)).toBe(15);
+    expect(buildValorIdeCreditCartOrder(25)).toEqual({
+      lineItems: [
+        {
+          sku: VALORIDE_CREDIT_PACKAGE.sku,
+          quantity: 5,
+          type: "product",
+        },
+      ],
+    });
+  });
+
+  it("uses hosted checkout return URLs and accepts common session URL fields", () => {
+    expect(buildValorIdeCheckoutUrls()).toEqual({
+      successUrl:
+        "https://valkyrlabs.com/checkout/success?session_id={CHECKOUT_SESSION_ID}&source=valoride",
+      cancelUrl: "https://valkyrlabs.com/cart?source=valoride",
+    });
+    expect(getCheckoutUrl({ checkout_url: " https://checkout.stripe.com/a " }))
+      .toBe("https://checkout.stripe.com/a");
+    expect(getCheckoutUrl({ checkoutUrl: "https://checkout.stripe.com/b" }))
+      .toBe("https://checkout.stripe.com/b");
   });
 });

--- a/webview-ui/src/services/creditsApi.ts
+++ b/webview-ui/src/services/creditsApi.ts
@@ -56,6 +56,98 @@ export interface PaymentTransaction {
   description?: string;
 }
 
+export interface CreateCartOrderLineArgs {
+  productId?: string;
+  sku?: string;
+  quantity?: number;
+  lineItemAmount?: number;
+  type?: string;
+}
+
+export interface CreateCartOrderArgs {
+  subtotalAmount?: number;
+  totalAmount?: number;
+  taxAmount?: number;
+  lineItems: CreateCartOrderLineArgs[];
+}
+
+export interface CreateCartOrderResponse {
+  id?: string;
+  orderId?: string;
+  lineItemCount?: number;
+  error?: string;
+  [key: string]: any;
+}
+
+export interface CreateCheckoutSessionArgs {
+  orderId: string;
+  successUrl: string;
+  cancelUrl: string;
+  currency?: string;
+  mode?: "payment" | "subscription";
+  idempotencyKey?: string;
+  amountCents?: never;
+  itemName?: never;
+  productType?: never;
+  sku?: never;
+  termMonths?: never;
+  creditsAmountCents?: never;
+}
+
+export interface CreateCheckoutSessionResponse {
+  session_id?: string;
+  checkout_url?: string;
+  checkoutUrl?: string;
+  url?: string;
+  error?: string;
+  [key: string]: any;
+}
+
+export const VALORIDE_CREDIT_PACKAGE = {
+  sku: "prod_ThB4xwTOkam2P3",
+  dollars: 5,
+  credits: 500,
+} as const;
+
+export const normalizeCreditCheckoutDollars = (dollars: number): number => {
+  if (!Number.isFinite(dollars)) {
+    return VALORIDE_CREDIT_PACKAGE.dollars;
+  }
+  return Math.max(
+    VALORIDE_CREDIT_PACKAGE.dollars,
+    Math.round(dollars / VALORIDE_CREDIT_PACKAGE.dollars) *
+      VALORIDE_CREDIT_PACKAGE.dollars,
+  );
+};
+
+export const buildValorIdeCreditCartOrder = (
+  dollars: number,
+): CreateCartOrderArgs => {
+  const normalizedDollars = normalizeCreditCheckoutDollars(dollars);
+  return {
+    lineItems: [
+      {
+        sku: VALORIDE_CREDIT_PACKAGE.sku,
+        quantity: normalizedDollars / VALORIDE_CREDIT_PACKAGE.dollars,
+        type: "product",
+      },
+    ],
+  };
+};
+
+export const buildValorIdeCheckoutUrls = () => ({
+  successUrl:
+    "https://valkyrlabs.com/checkout/success?session_id={CHECKOUT_SESSION_ID}&source=valoride",
+  cancelUrl: "https://valkyrlabs.com/cart?source=valoride",
+});
+
+export const getCheckoutUrl = (
+  payload: CreateCheckoutSessionResponse,
+): string | undefined => {
+  const url = payload.checkout_url ?? payload.checkoutUrl ?? payload.url;
+  return typeof url === "string" && url.trim() ? url.trim() : undefined;
+};
+
 const finiteNumber = (...values: unknown[]): number | undefined => {
   for (const value of values) {
     const numeric =
@@ -373,8 +465,59 @@ export const creditsApi = createApi({
     "Receipts",
     "AppGeneration",
     "GrayMatter",
+    "Checkout",
   ],
   endpoints: (builder) => ({
+    createCartOrder: builder.mutation<
+      CreateCartOrderResponse,
+      CreateCartOrderArgs
+    >({
+      query: (body) => ({
+        url: "checkout/cart-order",
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      }),
+      invalidatesTags: [],
+    }),
+
+    createCheckoutSession: builder.mutation<
+      CreateCheckoutSessionResponse,
+      CreateCheckoutSessionArgs
+    >({
+      query: ({
+        orderId,
+        successUrl,
+        cancelUrl,
+        currency,
+        mode,
+        idempotencyKey,
+      }) => {
+        const body: Record<string, string> = {
+          orderId,
+          successUrl,
+          cancelUrl,
+        };
+        if (currency) {
+          body.currency = currency;
+        }
+        if (mode) {
+          body.mode = mode;
+        }
+
+        return {
+          url: "checkout/create-session",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(idempotencyKey ? { "Idempotency-Key": idempotencyKey } : {}),
+          },
+          body,
+        };
+      },
+      invalidatesTags: [{ type: "Checkout", id: "SESSION" }],
+    }),
+
     /**
      * GET /v1/credits/{accountId}/balance
      * This is the SOURCE OF TRUTH for credit balance
@@ -706,6 +849,8 @@ export const creditsApi = createApi({
 export const {
   useGetAccountBalanceQuery,
   useLazyGetAccountBalanceQuery,
+  useCreateCartOrderMutation,
+  useCreateCheckoutSessionMutation,
   useRecordUsageTransactionMutation,
   useRecordPaymentTransactionMutation,
   useCreateAppGenerationRequestMutation,


### PR DESCRIPTION
## Summary
- replace ValorIDE BuyCredits direct ledger booking with server-owned cart order plus Stripe checkout session creation
- add pending checkout refresh state instead of promising instant client-assigned credits
- add checkout helper and component tests covering the Stripe handoff and no direct payment mutation
- add missing React Bootstrap runtime dependency and Testing Library DOM peer used by the touched component tests

Refs ValkyrLabs/ValkyrAI#3065

## Verification
- npm test -- --run src/services/creditsApi.test.ts src/components/BuyCredits/index.test.tsx
- npm run typecheck (blocked by existing repo-wide missing aliases/dependencies: @thorapi/model, redux-query, formik/yup, shared proto deps, and related generated surfaces)
