### PR TITLE
fix(graymatter): prevent silent raw-query context downgrade

### DIFF
--- a/src/services/graymatter/GrayMatterContextProvider.test.ts
+++ b/src/services/graymatter/GrayMatterContextProvider.test.ts
@@ -140,7 +140,7 @@ describe("GrayMatterContextProvider", () => {
     expect(result?.retrievalTraceIds).toEqual(["gm_trace_1", "gm_trace_2"]);
   });
 
-  it("falls back to MemoryEntry query when receipt retrieval is unavailable", async () => {
+  it("does not silently fall back to MemoryEntry query when receipt retrieval is unavailable", async () => {
     const appendLine = jest.fn();
     const provider = new GrayMatterContextProvider({ appendLine }, () => 1000);
     const queryMemory = jest.fn(async () => ({
@@ -163,14 +163,10 @@ describe("GrayMatterContextProvider", () => {
     );
 
     expect(retrieveMemoryWithReceipt).toHaveBeenCalledTimes(2);
-    expect(queryMemory).toHaveBeenCalledTimes(2);
-    expect(result?.formattedBlock).toContain("[gm:fallback-1] decision");
-    expect(result?.retrievalWarnings).toEqual([
-      "receipt_fallback:invariant",
-      "receipt_fallback:context",
-    ]);
+    expect(queryMemory).not.toHaveBeenCalled();
+    expect(result).toBeNull();
     expect(appendLine).toHaveBeenCalledWith(
-      expect.stringContaining("Receipt retrieval degraded"),
+      expect.stringContaining("omitting policy-required prompt context"),
     );
   });
 

--- a/src/services/graymatter/GrayMatterContextProvider.ts
+++ b/src/services/graymatter/GrayMatterContextProvider.ts
@@ -240,11 +240,10 @@ export class GrayMatterContextProvider {
       };
     } catch (error) {
       this.logger?.appendLine(
-        `[GrayMatterContextProvider] Receipt retrieval degraded for ${kind}; falling back to MemoryEntry/query: ${formatReadError(error)}`,
+        `[GrayMatterContextProvider] Receipt retrieval unavailable for ${kind}; omitting policy-required prompt context: ${formatReadError(error)}`,
       );
       return {
-        value: await withTimeout(config.queryMemory(query), timeoutMs),
-        warning: `receipt_fallback:${kind}`,
+        warning: `receipt_unavailable:${kind}`,
       };
     }
   }


### PR DESCRIPTION
## What Problem This Solves
Policy-required GrayMatter prompt context silently fell back to raw `MemoryEntry/query` reads when receipt retrieval failed.

## Why This Change Was Made
A failed receipt cannot be replaced with ungoverned context. The provider now omits that prompt context and records an explicit degraded warning.

## User Impact
Agents will retry, clarify, or surface the degraded state rather than act confidently from a lower-governance context.

## Evidence
- `git diff --check` passes.
- Focused test compilation is currently blocked by missing workspace dev type packages (`chai`, `mocha`, `node`, `should`, `vscode`); this is an unrelated dependency baseline issue.

Fixes ValkyrLabs/ValkyrAI#4119
Related to ValkyrLabs/ValkyrAI#4111